### PR TITLE
Fix converter bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ references
 scratch/
 *.egg-info/
 build/
+dist/
 perftemp.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = prefab_classes
-version = 0.6.0-alpha.2
+version = 0.6.0-alpha.3
 author = David C Ellis
 description = Boilerplate Generator for Classes
 classifiers =

--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.6.0-alpha.2"
+__version__ = "v0.6.0-alpha.3"
 PREFAB_MAGIC_BYTES = b"_".join([b"PREFAB_CLASSES", __version__.encode()])
 
 from .live import prefab, attribute

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -110,10 +110,16 @@ class Attribute:
         elif isinstance(value, DefaultFactory):
             # noinspection PyCallingNonCallable
             value = self.default_factory()
-        if self.converter and not self._converted:
-            self._converted = True
+
+        converted = getattr(obj, self.converted_flag, False)
+        if self.converter and not converted:
+            setattr(obj, self.converted_flag, True)
             value = self.converter(value)
         setattr(obj, self.private_name, value)
+
+    @property
+    def converted_flag(self):
+        return f"{self.private_name}_converted"
 
     # noinspection PyShadowingBuiltins
     def __init__(
@@ -152,7 +158,6 @@ class Attribute:
         self.default_factory = default_factory
 
         self.converter = converter
-        self._converted = False
 
         self.init = init
         self.repr = repr

--- a/tests/shared/test_converter.py
+++ b/tests/shared/test_converter.py
@@ -1,4 +1,3 @@
-import pytest
 from pathlib import Path
 
 
@@ -38,3 +37,12 @@ def test_converter_only_init(importer):
     pth.path = "alternate/directory"
 
     assert pth.path == "alternate/directory"  # This has not been converted to a path.
+
+
+def test_convert_twice(importer):
+    from converter import SystemPath
+
+    pth = SystemPath("fake/directory")
+    pth2 = SystemPath("fake/directory")
+
+    assert pth2.path == Path("fake/directory")

--- a/tests/shared/test_init.py
+++ b/tests/shared/test_init.py
@@ -109,3 +109,10 @@ def test_post_init(importer):
 
     x = PostInitExample()
     assert hasattr(x, "post_init_ran")
+
+
+def test_replace_factory_default(importer):
+    from init_ex import FactoryDefault
+
+    mut1 = FactoryDefault(x=[1, 2, 3])
+    assert mut1.x == [1, 2, 3]


### PR DESCRIPTION
'Live' prefabs would only convert their input once when the first instance was created. This resolves that so subsequent instances will also have converters run.