### PR TITLE
Rework internals of interpreted method

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,12 @@
 [metadata]
 name = prefab_classes
-version = 0.6.0-alpha.6
+version = 0.7.0
 author = David C Ellis
 description = Boilerplate Generator for Classes
 classifiers =
-    Development Status :: 1 - Planning
+    Development Status :: 3 - Alpha
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
 
 [options]

--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.6.0-alpha.6"
+__version__ = "v0.7.0"
 PREFAB_MAGIC_BYTES = b"_".join([b"PREFAB_CLASSES", __version__.encode()])
 
 from .live import prefab, attribute

--- a/src/prefab_classes/compiled/__init__.py
+++ b/src/prefab_classes/compiled/__init__.py
@@ -1,2 +1,2 @@
 from .import_hook import prefab_compiler
-from .preview_source import preview
+from .preview_source import preview_source, preview

--- a/src/prefab_classes/compiled/generator.py
+++ b/src/prefab_classes/compiled/generator.py
@@ -39,11 +39,15 @@ class Field:
         return ast.Call(func=self.converter, args=[arg], keywords=[])
 
     def ast_attribute(
-        self, obj_name="self", ctx: Union[type[ast.Load], type[ast.Store]] = ast.Load
+        self,
+        obj_name="self",
+        ctx: Union[type[ast.Load], type[ast.Store]] = ast.Load,
     ):
         """Get the ast.Attribute form for loading this attribute"""
         attrib = ast.Attribute(
-            value=ast.Name(id=obj_name, ctx=ast.Load()), attr=self.name, ctx=ctx()
+            value=ast.Name(id=obj_name, ctx=ast.Load()),
+            attr=self.name,
+            ctx=ctx(),
         )
         return attrib
 
@@ -142,7 +146,9 @@ class PrefabDetails:
         args = args if args else []
         keywords = keywords if keywords else []
         attrib = ast.Attribute(
-            value=ast.Name(id="self", ctx=ast.Load()), attr=method_name, ctx=ast.Load()
+            value=ast.Name(id="self", ctx=ast.Load()),
+            attr=method_name,
+            ctx=ast.Load(),
         )
         call = ast.Call(func=attrib, args=args, keywords=keywords)
         return ast.Expr(value=call)
@@ -264,7 +270,8 @@ class PrefabDetails:
             field_consts = [ast.Constant(value=name) for name in self.field_names]
             target = ast.Name(id=FIELDS_ATTRIBUTE, ctx=ast.Store())
             assignment = ast.Assign(
-                targets=[target], value=ast.List(elts=field_consts, ctx=ast.Load())
+                targets=[target],
+                value=ast.List(elts=field_consts, ctx=ast.Load()),
             )
 
             self.node.body.insert(1, assignment)
@@ -276,7 +283,7 @@ class PrefabDetails:
             return
 
         slot_consts = [ast.Constant(value=name) for name in self.field_names]
-        target = ast.Name(id='__slots__', ctx=ast.Store())
+        target = ast.Name(id="__slots__", ctx=ast.Store())
         assignment = ast.Assign(
             targets=[target], value=ast.Tuple(elts=slot_consts, ctx=ast.Load())
         )
@@ -390,7 +397,11 @@ class PrefabDetails:
         )
 
         init_func = ast.FunctionDef(
-            name=funcname, args=arguments, body=body, decorator_list=[], returns=None
+            name=funcname,
+            args=arguments,
+            body=body,
+            decorator_list=[],
+            returns=None,
         )
 
         self.node.body.append(init_func)
@@ -402,7 +413,11 @@ class PrefabDetails:
 
         arguments = [ast.arg(arg="self")]
         args = ast.arguments(
-            posonlyargs=[], args=arguments, kwonlyargs=[], kw_defaults=[], defaults=[]
+            posonlyargs=[],
+            args=arguments,
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
         )
 
         field_strings = [ast.Constant(value=f"{self.name}(")]
@@ -422,7 +437,11 @@ class PrefabDetails:
         body = [ast.Return(value=repr_string)]
 
         repr_func = ast.FunctionDef(
-            name="__repr__", args=args, body=body, decorator_list=[], returns=None
+            name="__repr__",
+            args=args,
+            body=body,
+            decorator_list=[],
+            returns=None,
         )
 
         self.node.body.append(repr_func)
@@ -440,7 +459,10 @@ class PrefabDetails:
         other_elts = []
 
         for field in self.field_list:
-            for obj_name, elt_list in [("self", class_elts), ("other", other_elts)]:
+            for obj_name, elt_list in [
+                ("self", class_elts),
+                ("other", other_elts),
+            ]:
                 elt_list.append(field.ast_attribute(obj_name))
 
         class_tuple = ast.Tuple(elts=class_elts, ctx=ast.Load())
@@ -453,10 +475,14 @@ class PrefabDetails:
 
         # (self.x, ...) == (other.x, ...) if self.__class__ == other.__class__ else NotImplemented
         left_ifexp = ast.Attribute(
-            value=ast.Name(id="self", ctx=ast.Load()), attr="__class__", ctx=ast.Load()
+            value=ast.Name(id="self", ctx=ast.Load()),
+            attr="__class__",
+            ctx=ast.Load(),
         )
         right_ifexp = ast.Attribute(
-            value=ast.Name(id="other", ctx=ast.Load()), attr="__class__", ctx=ast.Load()
+            value=ast.Name(id="other", ctx=ast.Load()),
+            attr="__class__",
+            ctx=ast.Load(),
         )
 
         class_expr = ast.IfExp(
@@ -468,7 +494,11 @@ class PrefabDetails:
         )
 
         args = ast.arguments(
-            posonlyargs=[], args=arguments, kwonlyargs=[], kw_defaults=[], defaults=[]
+            posonlyargs=[],
+            args=arguments,
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
         )
 
         body = [ast.Return(value=class_expr)]
@@ -490,11 +520,19 @@ class PrefabDetails:
         ]
 
         args = ast.arguments(
-            posonlyargs=[], args=arguments, kwonlyargs=[], kw_defaults=[], defaults=[]
+            posonlyargs=[],
+            args=arguments,
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
         )
 
         iter_func = ast.FunctionDef(
-            name="__iter__", args=args, body=body, decorator_list=[], returns=None
+            name="__iter__",
+            args=args,
+            body=body,
+            decorator_list=[],
+            returns=None,
         )
 
         self.node.body.append(iter_func)
@@ -553,7 +591,10 @@ class GatherPrefabs(ast.NodeVisitor):
                 kw.arg: getattr(kw.value, "value") for kw in prefab_decorator.keywords
             }
             prefab_details = PrefabDetails(
-                name=node.name, node=node, decorator=prefab_decorator, **keywords
+                name=node.name,
+                node=node,
+                decorator=prefab_decorator,
+                **keywords,
             )
 
             self.prefabs[prefab_details.name] = prefab_details

--- a/src/prefab_classes/compiled/preview_source.py
+++ b/src/prefab_classes/compiled/preview_source.py
@@ -1,8 +1,8 @@
 import ast
-from pathlib import Path
+import os
 
 
-def preview(pth: Path, use_black=True):
+def preview(pth: os.PathLike, use_black: bool = True):
     """
     Preview the result of running the generator on a python file
     This is mainly here for debugging and testing but can also be useful
@@ -15,9 +15,12 @@ def preview(pth: Path, use_black=True):
     """
     from .generator import compile_prefabs
 
-    source = pth.read_text()
+    with open(pth, mode="r", encoding="utf-8") as f:
+        source = f.read()
+
     tree = compile_prefabs(source)
-    if use_black:
+    # Black usage is not covered in case black changes formatting.
+    if use_black:  # pragma: no cover
         try:
             import black
 

--- a/src/prefab_classes/compiled/preview_source.py
+++ b/src/prefab_classes/compiled/preview_source.py
@@ -2,21 +2,8 @@ import ast
 import os
 
 
-def preview(pth: os.PathLike, use_black: bool = True):
-    """
-    Preview the result of running the generator on a python file
-    This is mainly here for debugging and testing but can also be useful
-    if users are unsure how the class will be generated.
-
-    :param pth: Path to the .py
-    :param use_black: use the black formatter to make the result easier to read
-                      if black is installed.
-    :return: string output of generated python code from the AST
-    """
+def preview_source(source: str, use_black: bool = True):
     from .generator import compile_prefabs
-
-    with open(pth, mode="r", encoding="utf-8") as f:
-        source = f.read()
 
     tree = compile_prefabs(source)
     # Black usage is not covered in case black changes formatting.
@@ -29,3 +16,20 @@ def preview(pth: os.PathLike, use_black: bool = True):
             return ast.unparse(tree)
     else:
         return ast.unparse(tree)
+
+
+def preview(pth: os.PathLike, use_black: bool = True):
+    """
+    Preview the result of running the generator on a python file
+    This is mainly here for debugging and testing but can also be useful
+    if users are unsure how the class will be generated.
+
+    :param pth: Path to the .py
+    :param use_black: use the black formatter to make the result easier to read
+                      if black is installed.
+    :return: string output of generated python code from the AST
+    """
+    with open(pth, mode="r", encoding="utf-8") as f:
+        source = f.read()
+
+    return preview_source(source, use_black=use_black)

--- a/src/prefab_classes/live/autogen.py
+++ b/src/prefab_classes/live/autogen.py
@@ -39,10 +39,8 @@
 # greater good.
 # ----------------------------------------------------------------------
 
-from .default_sentinels import DefaultValue, DefaultFactory
 
-
-def autogen(func):
+def autogen(func, globs=None):
     """
     Basically the cluegen function from David Beazley's cluegen
     Modified slightly due to other changes.
@@ -50,13 +48,14 @@ def autogen(func):
     Using this as a decorator indicates that the function will return a string
     which should be used to replace the function itself for that specific class.
     """
+    # globs can be a given empty dict, so specifically check for None.
+    globs = globs if globs is not None else {}
 
     def __get__(self, instance, cls):
         # Include the defaultvalue class used as a placeholder for defaults
-        global_vars = {"DefaultValue": DefaultValue, "DefaultFactory": DefaultFactory}
         local_vars = {}
         code = func(cls)
-        exec(code, global_vars, local_vars)
+        exec(code, globs, local_vars)
         # Having executed the code, the method should now exist
         # and can be retrieved by name from the dict
         method = local_vars[func.__name__]

--- a/src/prefab_classes/live/default_sentinels.py
+++ b/src/prefab_classes/live/default_sentinels.py
@@ -24,26 +24,3 @@
 # This shouldn't be used in any situation other than to compare with an is statement
 # So it doesn't need any complicated properties.
 _NOTHING = object()
-
-
-# Special Default Classes
-# When one of these is assigned to a descriptor the __set__ method
-# instead stores the default value of the descriptor
-class Default:
-    """Base Dummy Value Class"""
-
-    def __init__(self, value=None):
-        pass
-
-
-class DefaultValue(Default):
-    """
-    Dummy class for default values.
-    This avoids the actual default value being interpreted when exec is called.
-    """
-
-
-class DefaultFactory(Default):
-    """
-    Dummy class for default factories
-    """

--- a/src/prefab_classes/live/method_generators.py
+++ b/src/prefab_classes/live/method_generators.py
@@ -52,7 +52,7 @@ def get_init_maker(*, init_name="__init__"):
         kw_only_arglist = []
         for name, attrib in cls._attributes.items():
             if attrib.converter:
-                globs[f'_{name}_converter'] = attrib.converter
+                globs[f"_{name}_converter"] = attrib.converter
             if attrib.init:
                 if attrib.default is not _NOTHING:
                     if isinstance(attrib.default, (str, int, float, bool)):
@@ -62,13 +62,13 @@ def get_init_maker(*, init_name="__init__"):
                         # No guarantee repr will work for other objects
                         # so store the value in a variable and put it
                         # in the globals dict for eval
-                        arg = f'{name}=_{name}_default'
-                        globs[f'_{name}_default'] = attrib.default
+                        arg = f"{name}=_{name}_default"
+                        globs[f"_{name}_default"] = attrib.default
                 elif attrib.default_factory is not _NOTHING:
                     # Use NONE here and call the factory later
                     # This matches the behaviour of compiled
-                    arg = f'{name}=None'
-                    globs[f'_{name}_factory'] = attrib.default_factory
+                    arg = f"{name}=None"
+                    globs[f"_{name}_factory"] = attrib.default_factory
                 else:
                     arg = name
                 if attrib.kw_only:
@@ -78,9 +78,9 @@ def get_init_maker(*, init_name="__init__"):
             # Not in init, but need to set defaults
             else:
                 if attrib.default is not _NOTHING:
-                    globs[f'_{name}_default'] = attrib.default
+                    globs[f"_{name}_default"] = attrib.default
                 elif attrib.default_factory is not _NOTHING:
-                    globs[f'_{name}_factory'] = attrib.default_factory
+                    globs[f"_{name}_factory"] = attrib.default_factory
 
         pos_args = ", ".join(arglist)
         kw_args = ", ".join(kw_only_arglist)
@@ -120,7 +120,10 @@ def get_init_maker(*, init_name="__init__"):
         else:
             post_init_call = ""
 
-        code = f"def {init_name}(self, {args}):\n{pre_init_call}\n{body}\n{post_init_call}\n"
+        code = (
+            f"def {init_name}(self, {args}):"
+            f"\n{pre_init_call}\n{body}\n{post_init_call}\n"
+        )
 
         return code
 

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -204,9 +204,20 @@ def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False):
                 attrib = attribute()
                 new_attributes[name] = attrib
 
-        setattr(cls, f"_{cls.__name__}_attributes", new_attributes)
-    else:
-        setattr(cls, f"_{cls.__name__}_attributes", cls_attributes)
+        cls_attributes = new_attributes
+
+    setattr(cls, f"_{cls.__name__}_attributes", cls_attributes)
+
+    # Remove used attributes from the class dict and annotations to match compiled behaviour
+    for name in cls_attributes.keys():
+        try:
+            delattr(cls, name)
+        except AttributeError:
+            pass
+        try:
+            del cls.__annotations__[name]
+        except KeyError:
+            pass
 
     # Handle attributes
     attributes = {

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -53,7 +53,7 @@ from functools import partial
 
 from ..constants import FIELDS_ATTRIBUTE, COMPILED_FLAG
 from ..exceptions import PrefabError, LivePrefabError, CompiledPrefabError
-from .default_sentinels import DefaultFactory, DefaultValue, _NOTHING
+from .default_sentinels import _NOTHING
 from .method_generators import (
     init_maker,
     repr_maker,
@@ -64,64 +64,15 @@ from .method_generators import (
 
 
 class Attribute:
-    """
-    Descriptor class to define attributes.
+    __slots__ = (
+        "default",
+        "default_factory",
+        "converter",
+        "init",
+        "repr",
+        "kw_only"
+    )
 
-    This replaces the use of type hints in cluegen.
-    """
-
-    # noinspection PyProtectedMember
-    def __set_name__(self, owner, name):
-        # Here we append any generated attributes to a private variable
-        # This will be used instead of cluegen's all_clues.
-
-        # Make a new list for this class if it doesn't exist.
-        # The class name is used to avoid sharing a list with a parent class.
-        attribute_var = f"_{owner.__name__}_attributes"
-
-        try:
-            sub_attributes = getattr(owner, attribute_var)
-        except AttributeError:
-            sub_attributes = {}
-            setattr(owner, attribute_var, sub_attributes)
-
-        sub_attributes[name] = self
-
-        self.private_name = f"_prefab_attribute_{name}"
-
-    def __get__(self, obj, objtype=None):
-        # The default values here should only be used in the __init__ method
-        # This means that for a factory all it needs to know is that the default
-        # is a factory and not its value. So the default return for factory
-        # Attributes is DefaultFactory() and NOT self.default_factory().
-        # The actual value is set during __init__.
-        if self.default is not _NOTHING:
-            return getattr(obj, self.private_name, self.default)
-        if self.default_factory is not _NOTHING:
-            # noinspection PyCallingNonCallable
-            return getattr(obj, self.private_name, DefaultFactory())
-        return getattr(obj, self.private_name)
-
-    def __set__(self, obj, value):
-        # Detect if the value is a default placeholder and replace
-        # it with the real value.
-        if isinstance(value, DefaultValue):
-            value = self.default
-        elif isinstance(value, DefaultFactory):
-            # noinspection PyCallingNonCallable
-            value = self.default_factory()
-
-        converted = getattr(obj, self.converted_flag, False)
-        if self.converter and not converted:
-            setattr(obj, self.converted_flag, True)
-            value = self.converter(value)
-        setattr(obj, self.private_name, value)
-
-    @property
-    def converted_flag(self):
-        return f"{self.private_name}_converted"
-
-    # noinspection PyShadowingBuiltins
     def __init__(
         self,
         *,
@@ -132,36 +83,40 @@ class Attribute:
         repr=True,
         kw_only=False,
     ):
-        """
-        Create an Attribute for a prefab
-        :param default: Default value for this attribute
-        :param default_factory: No argument callable to give a default value (for otherwise mutable defaults)
-        :param converter: prefab.attr = x -> prefab.attr = converter(x)
-        :param init: Include this attribute in the __init__ parameters
-        :param repr: Include this attribute in the class __repr__
-        :param kw_only: Make this argument keyword only in init
-        """
+
         if not init and default is _NOTHING and default_factory is _NOTHING:
             raise LivePrefabError(
                 "Must provide a default value/factory if the attribute is not in init."
             )
-        if default is not _NOTHING and default_factory is not _NOTHING:
-            raise LivePrefabError(
-                "Cannot define both a default value and a default factory."
-            )
+
         if kw_only and not init:
             raise LivePrefabError(
                 "Attribute cannot be keyword only if it is not in init."
             )
 
+        if default is not _NOTHING and default_factory is not _NOTHING:
+            raise LivePrefabError(
+                "Cannot define both a default value and a default factory."
+            )
+
         self.default = default
         self.default_factory = default_factory
-
         self.converter = converter
-
         self.init = init
         self.repr = repr
         self.kw_only = kw_only
+
+    def __repr__(self):
+        return (
+            f"Attribute("
+            f"default={self.default!r}, "
+            f"default_factory={self.default_factory!r}, "
+            f"converter={self.converter!r}, "
+            f"init={self.init!r}, "
+            f"repr={self.repr!r}, "
+            f"kw_only={self.kw_only!r}"
+            f")"
+        )
 
 
 def attribute(
@@ -213,7 +168,11 @@ def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False):
     # annotations will be ignored as it becomes complex to fix the
     # ordering.
     annotation_names = getattr(cls, "__annotations__", {}).keys()
-    cls_attributes = getattr(cls, f"_{cls.__name__}_attributes", {})
+    cls_attributes = {
+        k: v for k, v in vars(cls).items()
+        if isinstance(v, Attribute)
+    }
+
     attribute_names = cls_attributes.keys()
 
     if set(annotation_names).issuperset(set(attribute_names)):
@@ -229,18 +188,14 @@ def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False):
                 else:
                     attribute_default = getattr(cls, name)
                     attrib = attribute(default=attribute_default)
-                    # Set private_name because set_name is never called
-                    attrib.private_name = f"_prefab_attribute_{name}"
-                    setattr(cls, name, attrib)
                     new_attributes[name] = attrib
             else:
                 attrib = attribute()
-                # Set private_name because set_name is never called
-                attrib.private_name = f"_prefab_attribute_{name}"
-                setattr(cls, name, attrib)
                 new_attributes[name] = attrib
 
         setattr(cls, f"_{cls.__name__}_attributes", new_attributes)
+    else:
+        setattr(cls, f"_{cls.__name__}_attributes", cls_attributes)
 
     # Handle attributes
     attributes = {

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -216,7 +216,8 @@ def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False):
             pass
         try:
             del cls.__annotations__[name]
-        except KeyError:
+        except (AttributeError, KeyError):
+            # AttributeError as 3.9 does not guarantee the existence of __annotations__
             pass
 
     # Handle attributes

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -70,7 +70,7 @@ class Attribute:
         "converter",
         "init",
         "repr",
-        "kw_only"
+        "kw_only",
     )
 
     def __init__(
@@ -83,10 +83,22 @@ class Attribute:
         repr=True,
         kw_only=False,
     ):
+        """
+        Initialize an Attribute
+
+        :param default: Default value for this attribute
+        :param default_factory: No argument callable to give a default value
+                                (for otherwise mutable defaults)
+        :param converter: prefab.attr = x -> prefab.attr = converter(x)
+        :param init: Include this attribute in the __init__ parameters
+        :param repr: Include this attribute in the class __repr__
+        :param kw_only: Make this argument keyword only in init
+        """
 
         if not init and default is _NOTHING and default_factory is _NOTHING:
             raise LivePrefabError(
-                "Must provide a default value/factory if the attribute is not in init."
+                "Must provide a default value/factory "
+                "if the attribute is not in init."
             )
 
         if kw_only and not init:
@@ -129,10 +141,12 @@ def attribute(
     kw_only=False,
 ):
     """
-    Get an Attribute instance - indirect to allow for potential changes in the future
+    Get an Attribute instance
+    indirect to allow for potential changes in the future
 
     :param default: Default value for this attribute
-    :param default_factory: No argument callable to give a default value (for otherwise mutable defaults)
+    :param default_factory: No argument callable to give a default value
+                            (for otherwise mutable defaults)
     :param converter: prefab.attr = x -> prefab.attr = converter(x)
     :param init: Include this attribute in the __init__ parameters
     :param repr: Include this attribute in the class __repr__
@@ -168,10 +182,7 @@ def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False):
     # annotations will be ignored as it becomes complex to fix the
     # ordering.
     annotation_names = getattr(cls, "__annotations__", {}).keys()
-    cls_attributes = {
-        k: v for k, v in vars(cls).items()
-        if isinstance(v, Attribute)
-    }
+    cls_attributes = {k: v for k, v in vars(cls).items() if isinstance(v, Attribute)}
 
     attribute_names = cls_attributes.keys()
 
@@ -263,8 +274,10 @@ def prefab(
     :param iter: generate __iter__
 
     :param compile_prefab: Direct the prefab compiler to compile this class
-    :param compile_fallback: Fail with a prefab error if the class has not been compiled
-    :param compile_plain: Do not include the COMPILED and PREFAB_FIELDS attributes after compilation
+    :param compile_fallback: Fail with a prefab error
+                             if the class has not been compiled
+    :param compile_plain: Do not include the COMPILED and PREFAB_FIELDS
+                          attributes after compilation
     :param compile_slots: Make the resulting compiled class use slots
     :return: class with __ methods defined
     """

--- a/tests/compiled/compile_targets/example_slots.py
+++ b/tests/compiled/compile_targets/example_slots.py
@@ -6,4 +6,3 @@ from prefab_classes import prefab
 class Coordinate:
     x: float
     y: float
-

--- a/tests/compiled/test_slots.py
+++ b/tests/compiled/test_slots.py
@@ -7,9 +7,9 @@ def test_has_slots():
     with prefab_compiler():
         from example_slots import Coordinate
 
-    assert hasattr(Coordinate, '__slots__')
+    assert hasattr(Coordinate, "__slots__")
 
-    assert Coordinate.__slots__ == ('x', 'y')
+    assert Coordinate.__slots__ == ("x", "y")
 
 
 @pytest.mark.usefixtures("compile_folder_modules")
@@ -20,12 +20,9 @@ def test_slots_work():
     c = Coordinate(0.0, 0.0)
 
     c.x, c.y = 1.0, 2.0
-    assert repr(c) == 'Coordinate(x=1.0, y=2.0)'
+    assert repr(c) == "Coordinate(x=1.0, y=2.0)"
 
     with pytest.raises(AttributeError):
         c.z = 3.0
 
-    assert not hasattr(c, '__dict__')
-
-
-
+    assert not hasattr(c, "__dict__")

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -1,0 +1,26 @@
+# COMPILE_PREFABS
+from prefab_classes import prefab, attribute
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class OnlyHints:
+    # Remove all 3 hints and values
+    x: int
+    y: int = 42
+    z: str = "Apple"
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class MixedHints:
+    # Remove y and z, leave x in annotations
+    x: int
+    y: int = attribute(default=42)
+    z = attribute(default="Apple")
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class AllPlainAssignment:
+    # remove all 3 values
+    x = attribute()
+    y = attribute(default=42)
+    z = attribute(default="Apple")

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -51,3 +51,31 @@ def test_no_attributes_error(importer):
         from fails.creation_6 import Empty
 
     assert e_info.value.args[0] == "Class must contain at least 1 attribute."
+
+
+def test_removed_annotations(importer):
+    from creation import OnlyHints
+
+    removed_attributes = ['x', 'y', 'z']
+    for attrib in removed_attributes:
+        assert attrib not in getattr(OnlyHints, '__dict__')
+        assert attrib not in getattr(OnlyHints, '__annotations__')
+
+
+def test_removed_only_used_annotations(importer):
+    from creation import MixedHints
+
+    assert 'x' in getattr(MixedHints, '__annotations__')
+
+    removed_attributes = ['y', 'z']
+    for attrib in removed_attributes:
+        assert attrib not in getattr(MixedHints, '__dict__')
+        assert attrib not in getattr(MixedHints, '__annotations__')
+
+
+def test_removed_attributes(importer):
+    from creation import AllPlainAssignment
+
+    removed_attributes = ['x', 'y', 'z']
+    for attrib in removed_attributes:
+        assert attrib not in getattr(AllPlainAssignment, '__dict__')

--- a/tests/shared/test_init.py
+++ b/tests/shared/test_init.py
@@ -85,9 +85,7 @@ def test_no_default(importer):
             "Coordinate.__init__() missing 1 required positional argument: 'y'"
         )
     else:
-        error_message = (
-            "__init__() missing 1 required positional argument: 'y'"
-        )
+        error_message = "__init__() missing 1 required positional argument: 'y'"
 
     assert e_info.value.args[0] == error_message
 


### PR DESCRIPTION
Major rewrite of the internals of the interpreted/live form of prefab.

Clean out most of the hidden internal variables from interpreted classes.
Now there should just be _attributes and _classname_attributes

Convert Attribute from a descriptor to a basic class. 

Defaults and Default Factory attributes are now handled simply in the __init__ method.