### PR TITLE
Fix slots inheritance to be correct to the slots documentation.

### DIFF
--- a/tests/compiled/compile_targets/example_slots.py
+++ b/tests/compiled/compile_targets/example_slots.py
@@ -6,3 +6,8 @@ from prefab_classes import prefab
 class Coordinate:
     x: float
     y: float
+
+
+@prefab(compile_prefab=True, compile_slots=True)
+class Coordinate3D(Coordinate):
+    z: float

--- a/tests/compiled/test_slots.py
+++ b/tests/compiled/test_slots.py
@@ -26,3 +26,18 @@ def test_slots_work():
         c.z = 3.0
 
     assert not hasattr(c, "__dict__")
+
+
+@pytest.mark.usefixtures("compile_folder_modules")
+def test_slots_inheritance():
+    # Child classes should only define *NEW* slots, not all slots.
+    # https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots
+    with prefab_compiler():
+        from example_slots import Coordinate, Coordinate3D
+
+    assert Coordinate.__slots__ == ("x", "y")
+    assert Coordinate3D.__slots__ == ('z', )
+
+    xyz = Coordinate3D(1.0, 2.0, 3.0)
+    assert (xyz.x, xyz.y, xyz.z) == (1.0, 2.0, 3.0)
+


### PR DESCRIPTION
https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots:~:text=(which%20should%20only%20contain%20names%20of%20any%20additional%20slots).