### PR TITLE
Generate the Attribute class as a compiled prefab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 88
 target-version = ['py311']
+extend-exclude = '''
+/(\_attribute\_class\.py)
+'''

--- a/src/prefab_classes/live/_attribute_class.py
+++ b/src/prefab_classes/live/_attribute_class.py
@@ -1,0 +1,70 @@
+from .default_sentinels import _NOTHING
+from ..exceptions import LivePrefabError
+
+
+class Attribute:
+    __slots__ = (
+        "default",
+        "default_factory",
+        "converter",
+        "init",
+        "repr",
+        "kw_only",
+    )
+
+    def __init__(
+        self,
+        *,
+        default=_NOTHING,
+        default_factory=_NOTHING,
+        converter=None,
+        init=True,
+        repr=True,
+        kw_only=False,
+    ):
+        """
+        Initialize an Attribute
+
+        :param default: Default value for this attribute
+        :param default_factory: No argument callable to give a default value
+                                (for otherwise mutable defaults)
+        :param converter: prefab.attr = x -> prefab.attr = converter(x)
+        :param init: Include this attribute in the __init__ parameters
+        :param repr: Include this attribute in the class __repr__
+        :param kw_only: Make this argument keyword only in init
+        """
+
+        if not init and default is _NOTHING and default_factory is _NOTHING:
+            raise LivePrefabError(
+                "Must provide a default value/factory "
+                "if the attribute is not in init."
+            )
+
+        if kw_only and not init:
+            raise LivePrefabError(
+                "Attribute cannot be keyword only if it is not in init."
+            )
+
+        if default is not _NOTHING and default_factory is not _NOTHING:
+            raise LivePrefabError(
+                "Cannot define both a default value and a default factory."
+            )
+
+        self.default = default
+        self.default_factory = default_factory
+        self.converter = converter
+        self.init = init
+        self.repr = repr
+        self.kw_only = kw_only
+
+    def __repr__(self):
+        return (
+            f"Attribute("
+            f"default={self.default!r}, "
+            f"default_factory={self.default_factory!r}, "
+            f"converter={self.converter!r}, "
+            f"init={self.init!r}, "
+            f"repr={self.repr!r}, "
+            f"kw_only={self.kw_only!r}"
+            f")"
+        )

--- a/src/prefab_classes/live/_attribute_class.py
+++ b/src/prefab_classes/live/_attribute_class.py
@@ -1,70 +1,36 @@
+# DO NOT MANUALLY EDIT THIS FILE
+# THIS MODULE IS AUTOMATICALLY GENERATED FROM _attribute_template.py
+# BY regenerate_attribute.py
+# MODIFY THOSE MODULES AND RERUN regenerate_attribute.py
+
 from .default_sentinels import _NOTHING
 from ..exceptions import LivePrefabError
 
-
 class Attribute:
-    __slots__ = (
-        "default",
-        "default_factory",
-        "converter",
-        "init",
-        "repr",
-        "kw_only",
-    )
+    __match_args__ = ('default', 'default_factory', 'converter', 'init', 'repr', 'kw_only')
+    COMPILED = True
+    PREFAB_FIELDS = ['default', 'default_factory', 'converter', 'init', 'repr', 'kw_only']
+    __slots__ = ('default', 'default_factory', 'converter', 'init', 'repr', 'kw_only')
 
-    def __init__(
-        self,
-        *,
-        default=_NOTHING,
-        default_factory=_NOTHING,
-        converter=None,
-        init=True,
-        repr=True,
-        kw_only=False,
-    ):
-        """
-        Initialize an Attribute
+    def __prefab_post_init__(self):
+        if not self.init and self.default is _NOTHING and (self.default_factory is _NOTHING):
+            raise LivePrefabError('Must provide a default value/factory if the attribute is not in init.')
+        if self.kw_only and (not self.init):
+            raise LivePrefabError('Attribute cannot be keyword only if it is not in init.')
+        if self.default is not _NOTHING and self.default_factory is not _NOTHING:
+            raise LivePrefabError('Cannot define both a default value and a default factory.')
 
-        :param default: Default value for this attribute
-        :param default_factory: No argument callable to give a default value
-                                (for otherwise mutable defaults)
-        :param converter: prefab.attr = x -> prefab.attr = converter(x)
-        :param init: Include this attribute in the __init__ parameters
-        :param repr: Include this attribute in the class __repr__
-        :param kw_only: Make this argument keyword only in init
-        """
-
-        if not init and default is _NOTHING and default_factory is _NOTHING:
-            raise LivePrefabError(
-                "Must provide a default value/factory "
-                "if the attribute is not in init."
-            )
-
-        if kw_only and not init:
-            raise LivePrefabError(
-                "Attribute cannot be keyword only if it is not in init."
-            )
-
-        if default is not _NOTHING and default_factory is not _NOTHING:
-            raise LivePrefabError(
-                "Cannot define both a default value and a default factory."
-            )
-
+    def __init__(self, default=_NOTHING, default_factory=_NOTHING, converter=None, init: bool=True, repr: bool=True, kw_only: bool=False):
         self.default = default
         self.default_factory = default_factory
         self.converter = converter
         self.init = init
         self.repr = repr
         self.kw_only = kw_only
+        self.__prefab_post_init__()
 
     def __repr__(self):
-        return (
-            f"Attribute("
-            f"default={self.default!r}, "
-            f"default_factory={self.default_factory!r}, "
-            f"converter={self.converter!r}, "
-            f"init={self.init!r}, "
-            f"repr={self.repr!r}, "
-            f"kw_only={self.kw_only!r}"
-            f")"
-        )
+        return f'Attribute(default={self.default!r}, default_factory={self.default_factory!r}, converter={self.converter!r}, init={self.init!r}, repr={self.repr!r}, kw_only={self.kw_only!r})'
+
+    def __eq__(self, other):
+        return (self.default, self.default_factory, self.converter, self.init, self.repr, self.kw_only) == (other.default, other.default_factory, other.converter, other.init, other.repr, other.kw_only) if self.__class__ == other.__class__ else NotImplemented

--- a/src/prefab_classes/live/_attribute_class_maker/_attribute_template.py
+++ b/src/prefab_classes/live/_attribute_class_maker/_attribute_template.py
@@ -1,0 +1,43 @@
+# COMPILE_PREFABS
+# !THIS IMPORT MUST STAY AT THE TOP!
+from prefab_classes import prefab, attribute
+
+# noinspection PyUnresolvedReferences
+from .default_sentinels import _NOTHING
+
+# noinspection PyUnresolvedReferences
+from ..exceptions import LivePrefabError
+
+
+@prefab(compile_prefab=True, compile_slots=True)
+class Attribute:
+    # Note that the interpreted form of prefab would fail here
+    # as it would interpret _NOTHING as no value provided
+    # compiled prefabs do not interpret this way.
+    default = attribute(default=_NOTHING)
+    default_factory = attribute(default=_NOTHING)
+    converter = attribute(default=None)
+    init: bool = attribute(default=True)
+    repr: bool = attribute(default=True)
+    kw_only: bool = attribute(default=False)
+
+    def __prefab_post_init__(self):
+        if (
+            not self.init
+            and self.default is _NOTHING
+            and self.default_factory is _NOTHING
+        ):
+            raise LivePrefabError(
+                "Must provide a default value/factory "
+                "if the attribute is not in init."
+            )
+
+        if self.kw_only and not self.init:
+            raise LivePrefabError(
+                "Attribute cannot be keyword only if it is not in init."
+            )
+
+        if self.default is not _NOTHING and self.default_factory is not _NOTHING:
+            raise LivePrefabError(
+                "Cannot define both a default value and a default factory."
+            )

--- a/src/prefab_classes/live/_attribute_class_maker/regenerate_attribute.py
+++ b/src/prefab_classes/live/_attribute_class_maker/regenerate_attribute.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from prefab_classes.compiled import preview
+
+
+TEMPLATE_FILE = Path(__file__).parent / '_attribute_template.py'
+OUTPUT_FILE = Path(__file__).parents[1] / '_attribute_class.py'
+
+
+GENERATED_NOTIFICATION = """
+# DO NOT MANUALLY EDIT THIS FILE
+# THIS MODULE IS AUTOMATICALLY GENERATED FROM _attribute_template.py
+# BY regenerate_attribute.py
+# MODIFY THOSE MODULES AND RERUN regenerate_attribute.py
+""".strip()
+
+
+def generate_attribute_source():
+    code = preview(TEMPLATE_FILE, use_black=False)
+    # Delete the first line
+    code = '\n'.join(code.split('\n')[1:])
+
+    source = f"{GENERATED_NOTIFICATION}\n\n{code}"
+    return source
+
+
+def write_attribute_module():
+    source = generate_attribute_source()
+    OUTPUT_FILE.write_text(source)
+
+
+if __name__ == '__main__':
+    write_attribute_module()

--- a/src/prefab_classes/live/_attribute_class_maker/regenerate_attribute.py
+++ b/src/prefab_classes/live/_attribute_class_maker/regenerate_attribute.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from prefab_classes.compiled import preview
 
 
-TEMPLATE_FILE = Path(__file__).parent / '_attribute_template.py'
-OUTPUT_FILE = Path(__file__).parents[1] / '_attribute_class.py'
+TEMPLATE_FILE = Path(__file__).parent / "_attribute_template.py"
+OUTPUT_FILE = Path(__file__).parents[1] / "_attribute_class.py"
 
 
 GENERATED_NOTIFICATION = """
@@ -18,7 +18,7 @@ GENERATED_NOTIFICATION = """
 def generate_attribute_source():
     code = preview(TEMPLATE_FILE, use_black=False)
     # Delete the first line
-    code = '\n'.join(code.split('\n')[1:])
+    code = "\n".join(code.split("\n")[1:])
 
     source = f"{GENERATED_NOTIFICATION}\n\n{code}"
     return source
@@ -29,5 +29,5 @@ def write_attribute_module():
     OUTPUT_FILE.write_text(source)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     write_attribute_module()

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -51,7 +51,7 @@ from functools import partial
 # noinspection PyUnresolvedReferences
 # from typing import dataclass_transform
 
-
+from ._attribute_class import Attribute
 from ..constants import FIELDS_ATTRIBUTE, COMPILED_FLAG, CLASSVAR_NAME
 from ..exceptions import PrefabError, LivePrefabError, CompiledPrefabError
 from .default_sentinels import _NOTHING
@@ -62,74 +62,6 @@ from .method_generators import (
     iter_maker,
     prefab_init_maker,
 )
-
-
-class Attribute:
-    __slots__ = (
-        "default",
-        "default_factory",
-        "converter",
-        "init",
-        "repr",
-        "kw_only",
-    )
-
-    def __init__(
-        self,
-        *,
-        default=_NOTHING,
-        default_factory=_NOTHING,
-        converter=None,
-        init=True,
-        repr=True,
-        kw_only=False,
-    ):
-        """
-        Initialize an Attribute
-
-        :param default: Default value for this attribute
-        :param default_factory: No argument callable to give a default value
-                                (for otherwise mutable defaults)
-        :param converter: prefab.attr = x -> prefab.attr = converter(x)
-        :param init: Include this attribute in the __init__ parameters
-        :param repr: Include this attribute in the class __repr__
-        :param kw_only: Make this argument keyword only in init
-        """
-
-        if not init and default is _NOTHING and default_factory is _NOTHING:
-            raise LivePrefabError(
-                "Must provide a default value/factory "
-                "if the attribute is not in init."
-            )
-
-        if kw_only and not init:
-            raise LivePrefabError(
-                "Attribute cannot be keyword only if it is not in init."
-            )
-
-        if default is not _NOTHING and default_factory is not _NOTHING:
-            raise LivePrefabError(
-                "Cannot define both a default value and a default factory."
-            )
-
-        self.default = default
-        self.default_factory = default_factory
-        self.converter = converter
-        self.init = init
-        self.repr = repr
-        self.kw_only = kw_only
-
-    def __repr__(self):
-        return (
-            f"Attribute("
-            f"default={self.default!r}, "
-            f"default_factory={self.default_factory!r}, "
-            f"converter={self.converter!r}, "
-            f"init={self.init!r}, "
-            f"repr={self.repr!r}, "
-            f"kw_only={self.kw_only!r}"
-            f")"
-        )
 
 
 def attribute(
@@ -166,7 +98,9 @@ def attribute(
 
 
 # @dataclass_transform(field_specifiers=(attribute, Attribute))
-def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False, match_args=True):
+def _make_prefab(
+    cls: type, *, init=True, repr=True, eq=True, iter=False, match_args=True
+):
     """
     Generate boilerplate code for dunder methods in a class.
 
@@ -188,12 +122,15 @@ def _make_prefab(cls: type, *, init=True, repr=True, eq=True, iter=False, match_
     # Eliminate ClassVars - don't want to import typing if
     # it's not already imported
     if annotations:
-        _typing = sys.modules.get('typing')
+        _typing = sys.modules.get("typing")
         if _typing:
             new_annotations = {}
             for key, value in annotations.items():
                 # Actual class used as annotation
-                if value is _typing.ClassVar or getattr(value, '__origin__', None) is _typing.ClassVar:
+                if (
+                    value is _typing.ClassVar
+                    or getattr(value, "__origin__", None) is _typing.ClassVar
+                ):
                     continue
                 # String used as annotation
                 elif isinstance(value, str) and CLASSVAR_NAME in value:
@@ -347,4 +284,6 @@ def prefab(
         else:
             # Create Live Version
             setattr(cls, COMPILED_FLAG, False)
-            return _make_prefab(cls, init=init, repr=repr, eq=eq, iter=iter, match_args=match_args)
+            return _make_prefab(
+                cls, init=init, repr=repr, eq=eq, iter=iter, match_args=match_args
+            )

--- a/tests/compiled/test_slots.py
+++ b/tests/compiled/test_slots.py
@@ -36,8 +36,7 @@ def test_slots_inheritance():
         from example_slots import Coordinate, Coordinate3D
 
     assert Coordinate.__slots__ == ("x", "y")
-    assert Coordinate3D.__slots__ == ('z', )
+    assert Coordinate3D.__slots__ == ("z",)
 
     xyz = Coordinate3D(1.0, 2.0, 3.0)
     assert (xyz.x, xyz.y, xyz.z) == (1.0, 2.0, 3.0)
-

--- a/tests/live/test_attribute_template.py
+++ b/tests/live/test_attribute_template.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import prefab_classes.live._attribute_class as attribute_module
+from prefab_classes.live._attribute_class_maker.regenerate_attribute import generate_attribute_source
+
+
+def test_template_matches_attribute():
+    output_file = Path(attribute_module.__file__)
+
+    template_output = generate_attribute_source()
+
+    assert template_output == output_file.read_text()

--- a/tests/live/test_attribute_template.py
+++ b/tests/live/test_attribute_template.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
 import prefab_classes.live._attribute_class as attribute_module
-from prefab_classes.live._attribute_class_maker.regenerate_attribute import generate_attribute_source
+from prefab_classes.live._attribute_class_maker.regenerate_attribute import (
+    generate_attribute_source,
+)
 
 
 def test_template_matches_attribute():

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -32,6 +32,6 @@ class AllPlainAssignment:
 class IgnoreClassVars:
     # Ignore X, Y and Z - Include actual.
     x: typing.ClassVar[int] = 42
-    y: ClassVar[str] = 'Apple'
-    z: 'ClassVar[float]' = 3.14
-    actual: str = 'Test'
+    y: ClassVar[str] = "Apple"
+    z: "ClassVar[float]" = 3.14
+    actual: str = "Test"

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -57,40 +57,40 @@ def test_no_attributes_error(importer):
 def test_removed_annotations(importer):
     from creation import OnlyHints
 
-    removed_attributes = ['x', 'y', 'z']
+    removed_attributes = ["x", "y", "z"]
     for attrib in removed_attributes:
-        assert attrib not in getattr(OnlyHints, '__dict__')
-        assert attrib not in getattr(OnlyHints, '__annotations__', {})
+        assert attrib not in getattr(OnlyHints, "__dict__")
+        assert attrib not in getattr(OnlyHints, "__annotations__", {})
 
 
 def test_removed_only_used_annotations(importer):
     from creation import MixedHints
 
-    assert 'x' in getattr(MixedHints, '__annotations__')
+    assert "x" in getattr(MixedHints, "__annotations__")
 
-    removed_attributes = ['y', 'z']
+    removed_attributes = ["y", "z"]
     for attrib in removed_attributes:
-        assert attrib not in getattr(MixedHints, '__dict__')
-        assert attrib not in getattr(MixedHints, '__annotations__', {})
+        assert attrib not in getattr(MixedHints, "__dict__")
+        assert attrib not in getattr(MixedHints, "__annotations__", {})
 
 
 def test_removed_attributes(importer):
     from creation import AllPlainAssignment
 
-    removed_attributes = ['x', 'y', 'z']
+    removed_attributes = ["x", "y", "z"]
     for attrib in removed_attributes:
-        assert attrib not in getattr(AllPlainAssignment, '__dict__')
+        assert attrib not in getattr(AllPlainAssignment, "__dict__")
 
 
 def test_skipped_classvars(importer):
     from creation import IgnoreClassVars
 
     fields = getattr(IgnoreClassVars, FIELDS_ATTRIBUTE)
-    assert 'x' not in fields
-    assert 'y' not in fields
-    assert 'z' not in fields
-    assert 'actual' in fields
+    assert "x" not in fields
+    assert "y" not in fields
+    assert "z" not in fields
+    assert "actual" in fields
 
-    assert 'x' in getattr(IgnoreClassVars, '__dict__')
-    assert 'y' in getattr(IgnoreClassVars, '__dict__')
-    assert 'z' in getattr(IgnoreClassVars, '__dict__')
+    assert "x" in getattr(IgnoreClassVars, "__dict__")
+    assert "y" in getattr(IgnoreClassVars, "__dict__")
+    assert "z" in getattr(IgnoreClassVars, "__dict__")

--- a/tests/shared/test_dunders.py
+++ b/tests/shared/test_dunders.py
@@ -45,10 +45,11 @@ def test_neq(importer):
     assert (x.x, x.y, x.z, x.t) != (y.x, y.y, y.z, y.t)
     assert x != y
 
+
 def test_match_args(importer):
     from dunders import Coordinate4D
 
-    assert Coordinate4D.__match_args__ == ('x', 'y', 'z', 't')
+    assert Coordinate4D.__match_args__ == ("x", "y", "z", "t")
 
 
 def test_match_args_disabled(importer):


### PR DESCRIPTION
Attribute was a hand written class, replace it with a compiled prefab that has been output as source. 

Include the template and code to regenerate this class if changes are made. 

Check the template output matches the current class.