### PR TITLE
Don't overwrite existing dunders

### DIFF
--- a/src/prefab_classes/live/_attribute_class.py
+++ b/src/prefab_classes/live/_attribute_class.py
@@ -7,18 +7,10 @@ from .default_sentinels import _NOTHING
 from ..exceptions import LivePrefabError
 
 class Attribute:
-    __match_args__ = ('default', 'default_factory', 'converter', 'init', 'repr', 'kw_only')
     COMPILED = True
     PREFAB_FIELDS = ['default', 'default_factory', 'converter', 'init', 'repr', 'kw_only']
     __slots__ = ('default', 'default_factory', 'converter', 'init', 'repr', 'kw_only')
-
-    def __prefab_post_init__(self):
-        if not self.init and self.default is _NOTHING and (self.default_factory is _NOTHING):
-            raise LivePrefabError('Must provide a default value/factory if the attribute is not in init.')
-        if self.kw_only and (not self.init):
-            raise LivePrefabError('Attribute cannot be keyword only if it is not in init.')
-        if self.default is not _NOTHING and self.default_factory is not _NOTHING:
-            raise LivePrefabError('Cannot define both a default value and a default factory.')
+    __match_args__ = ('default', 'default_factory', 'converter', 'init', 'repr', 'kw_only')
 
     def __init__(self, default=_NOTHING, default_factory=_NOTHING, converter=None, init: bool=True, repr: bool=True, kw_only: bool=False):
         self.default = default
@@ -34,3 +26,11 @@ class Attribute:
 
     def __eq__(self, other):
         return (self.default, self.default_factory, self.converter, self.init, self.repr, self.kw_only) == (other.default, other.default_factory, other.converter, other.init, other.repr, other.kw_only) if self.__class__ == other.__class__ else NotImplemented
+
+    def __prefab_post_init__(self):
+        if not self.init and self.default is _NOTHING and (self.default_factory is _NOTHING):
+            raise LivePrefabError('Must provide a default value/factory if the attribute is not in init.')
+        if self.kw_only and (not self.init):
+            raise LivePrefabError('Attribute cannot be keyword only if it is not in init.')
+        if self.default is not _NOTHING and self.default_factory is not _NOTHING:
+            raise LivePrefabError('Cannot define both a default value and a default factory.')

--- a/src/prefab_classes/live/prefab.py
+++ b/src/prefab_classes/live/prefab.py
@@ -180,18 +180,18 @@ def _make_prefab(
 
     setattr(cls, FIELDS_ATTRIBUTE, [name for name in attributes])
     cls._attributes = attributes
-    if match_args:
+    if match_args and '__match_args__' not in cls.__dict__:
         cls.__match_args__ = tuple(name for name in attributes)
 
-    if init:
+    if init and '__init__' not in cls.__dict__:
         setattr(cls, "__init__", init_maker)
     else:
         setattr(cls, "__prefab_init__", prefab_init_maker)
-    if repr:
+    if repr and '__repr__' not in cls.__dict__:
         setattr(cls, "__repr__", repr_maker)
-    if eq:
+    if eq and '__eq__' not in cls.__dict__:
         setattr(cls, "__eq__", eq_maker)
-    if iter:
+    if iter and '__iter__' not in cls.__dict__:
         setattr(cls, "__iter__", iter_maker)
 
     return cls

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -35,7 +35,7 @@ class KeepDefinedMethods:
 
     __match_args__ = ('x', )
 
-    def __init__(self, x, y):
+    def __init__(self, x=0, y=0):
         self.x = 0
         self.y = 0
 

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -28,6 +28,27 @@ class AllPlainAssignment:
     z = attribute(default="Apple")
 
 
+@prefab(compile_prefab=True, compile_fallback=True, iter=True, match_args=True)
+class KeepDefinedMethods:
+    x: int = -1
+    y: int = -1
+
+    __match_args__ = ('x', )
+
+    def __init__(self, x, y):
+        self.x = 0
+        self.y = 0
+
+    def __repr__(self):
+        return "ORIGINAL REPR"
+
+    def __eq__(self, other):
+        return False
+
+    def __iter__(self):
+        yield from ['ORIGINAL ITER']
+
+
 @prefab(compile_prefab=True, compile_fallback=True)
 class IgnoreClassVars:
     # Ignore v, w, x, y and z - Include actual.


### PR DESCRIPTION
Another #14 feature.

if __init__, __repr__, etc exist in a class already they will not be overwritten by the decorator.

Also clean up the compiled generation to do the AST insertion all in 1 place.