### PR TITLE
Improve dynamic import performance

### DIFF
--- a/perf/profile.py
+++ b/perf/profile.py
@@ -154,6 +154,16 @@ class C{n}:
     e: int
 '''
 
+prefab_attribute_template = '''
+@prefab
+class C{n}:
+    a = attribute()
+    b = attribute()
+    c = attribute()
+    d = attribute()
+    e = attribute()
+'''
+
 prefab_eval_template = '''
 @prefab
 class C{n}:
@@ -282,6 +292,9 @@ def main(reps, test_everything=False, exclude_compile=False):
 
     write_perftemp(100, prefab_template, prefab_import)
     run_test('prefab', reps, exclude_compile=exclude_compile)
+
+    write_perftemp(100, prefab_attribute_template, prefab_import)
+    run_test('prefab_attributes', reps, exclude_compile=exclude_compile)
 
     write_perftemp(100, prefab_eval_template, prefab_import)
     run_test('prefab_eval', reps, exclude_compile=exclude_compile)


### PR DESCRIPTION
With additional features being added there ended up being a number of extra loops over the attributes. Annotated classes in particular looped over the attributes multiple times. 

There is still some potential for improvement but this took the import performance test from somewhere around 0.5s to closer to 0.4s.

The performance test now includes a separate test for prefabs defined using `attribute()` directly.