### PR TITLE
Allow explicit inheritance from object in compiled prefabs.

### DIFF
--- a/src/prefab_classes/compiled/generator.py
+++ b/src/prefab_classes/compiled/generator.py
@@ -341,7 +341,10 @@ class PrefabDetails:
 
     @cached_property
     def parents(self):
-        parents = [getattr(item, "id") for item in self.node.bases]
+        parents = [
+            getattr(item, "id") for item in self.node.bases
+            if getattr(item, "id") != "object"  # Ignore inheritance from object
+        ]
         if self.name in parents:
             raise CompiledPrefabError(f"Class {self.name} cannot inherit from itself.")
         return parents

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -319,8 +319,7 @@ def prefab(
     :param kw_only: make all attributes keyword only
 
     :param compile_prefab: Direct the prefab compiler to compile this class
-    :param compile_fallback: Fail with a prefab error
-                             if the class has not been compiled
+    :param compile_fallback: Fallback to a dynamic prefab if not compiled.
     :param compile_plain: Do not include the COMPILED and PREFAB_FIELDS
                           attributes after compilation
     :param compile_slots: Make the resulting compiled class use slots

--- a/tests/shared/examples/inheritance.py
+++ b/tests/shared/examples/inheritance.py
@@ -3,6 +3,11 @@ from prefab_classes import prefab, attribute
 
 
 @prefab(compile_prefab=True, compile_fallback=True)
+class InheritObject(object):
+    pass
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
 class Coordinate:
     x: float
     y: float

--- a/tests/shared/test_inheritance.py
+++ b/tests/shared/test_inheritance.py
@@ -2,6 +2,15 @@
 import pytest
 
 
+def test_inherit_object(importer):
+    from inheritance import InheritObject
+
+    x = InheritObject()
+    y = InheritObject()
+
+    assert x == y
+
+
 def test_basic_inheritance(importer):
     from inheritance import Coordinate3D
 


### PR DESCRIPTION
'object' is now ignored in the inheritance tree for compiled prefabs, previously it would cause an error as compiled prefabs can only inherit from other compiled prefabs and 'object' is not one.