### PR TITLE
Improve the import time by delaying or removing stdlib imports

### DIFF
--- a/src/prefab_classes/_typing.py
+++ b/src/prefab_classes/_typing.py
@@ -1,0 +1,68 @@
+# Importing the typing module is slow
+# However the dataclass_transform annotation is useful
+# It's copied here
+
+def dataclass_transform(
+    *,
+    eq_default: bool = True,
+    order_default: bool = False,
+    kw_only_default: bool = False,
+    field_specifiers: tuple = (),
+    **kwargs,
+):
+    """Decorator that marks a function, class, or metaclass as providing
+    dataclass-like behavior.
+    Example usage with a decorator function:
+        T = TypeVar("T")
+        @dataclass_transform()
+        def create_model(cls: type[T]) -> type[T]:
+            ...
+            return cls
+        @create_model
+        class CustomerModel:
+            id: int
+            name: str
+    On a base class:
+        @dataclass_transform()
+        class ModelBase: ...
+        class CustomerModel(ModelBase):
+            id: int
+            name: str
+    On a metaclass:
+        @dataclass_transform()
+        class ModelMeta(type): ...
+        class ModelBase(metaclass=ModelMeta): ...
+        class CustomerModel(ModelBase):
+            id: int
+            name: str
+    The ``CustomerModel`` classes defined above will
+    be treated by type checkers similarly to classes created with
+    ``@dataclasses.dataclass``.
+    For example, type checkers will assume these classes have
+    ``__init__`` methods that accept ``id`` and ``name``.
+    The arguments to this decorator can be used to customize this behavior:
+    - ``eq_default`` indicates whether the ``eq`` parameter is assumed to be
+        ``True`` or ``False`` if it is omitted by the caller.
+    - ``order_default`` indicates whether the ``order`` parameter is
+        assumed to be True or False if it is omitted by the caller.
+    - ``kw_only_default`` indicates whether the ``kw_only`` parameter is
+        assumed to be True or False if it is omitted by the caller.
+    - ``field_specifiers`` specifies a static list of supported classes
+        or functions that describe fields, similar to ``dataclasses.field()``.
+    - Arbitrary other keyword arguments are accepted in order to allow for
+        possible future extensions.
+    At runtime, this decorator records its arguments in the
+    ``__dataclass_transform__`` attribute on the decorated object.
+    It has no other runtime effect.
+    See PEP 681 for more details.
+    """
+    def decorator(cls_or_fn):
+        cls_or_fn.__dataclass_transform__ = {
+            "eq_default": eq_default,
+            "order_default": order_default,
+            "kw_only_default": kw_only_default,
+            "field_specifiers": field_specifiers,
+            "kwargs": kwargs,
+        }
+        return cls_or_fn
+    return decorator

--- a/src/prefab_classes/compiled/rewrite_source.py
+++ b/src/prefab_classes/compiled/rewrite_source.py
@@ -1,6 +1,3 @@
-import os
-from typing import Union
-
 from ..exceptions import CompiledPrefabError
 
 
@@ -29,7 +26,7 @@ def rewrite_code(source: str, *, use_black: bool = False):
         return ast.unparse(tree)
 
 
-def preview(pth: Union[str, os.PathLike], *, use_black: bool = True):
+def preview(pth, *, use_black: bool = True):
     """
     Preview the result of running the generator on a python file
     This is mainly here for debugging and testing but can also be useful
@@ -47,8 +44,8 @@ def preview(pth: Union[str, os.PathLike], *, use_black: bool = True):
 
 
 def rewrite_to_py(
-    source_path: Union[str, os.PathLike],
-    dest_path: Union[str, os.PathLike],
+    source_path,
+    dest_path,
     *,
     header_comment: str = COMPILE_COMMENT,
     use_black: bool = False,

--- a/src/prefab_classes/compiled/rewrite_source.py
+++ b/src/prefab_classes/compiled/rewrite_source.py
@@ -1,4 +1,3 @@
-import ast
 import os
 from typing import Union
 
@@ -14,6 +13,7 @@ COMPILE_COMMENT = """
 
 
 def rewrite_code(source: str, *, use_black: bool = False):
+    import ast
     from .generator import compile_prefabs
 
     tree = compile_prefabs(source)

--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -38,7 +38,9 @@
 # the source code.  There is no warranty.  Try to use the code for the
 # greater good.
 # ----------------------------------------------------------------------
-import inspect
+
+# inspect is now imported lazily when needed as it is a slow import.
+# import inspect
 
 from ..constants import (
     PRE_INIT_FUNC,
@@ -122,6 +124,7 @@ def get_init_maker(*, init_name="__init__"):
             except AttributeError:
                 pass
             else:
+                import inspect
                 for item in inspect.signature(func).parameters.keys():
                     if item != "self":
                         func_arglist.append(item)

--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -48,7 +48,7 @@ from ..constants import (
     PREFAB_INIT_FUNC,
     FIELDS_ATTRIBUTE,
 )
-from prefab_classes.sentinels import NOTHING
+from ..sentinels import NOTHING
 from .autogen import autogen
 
 

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -32,11 +32,17 @@ from functools import partial
 # So now it's imported only when analyzing those functions
 # import inspect
 
-try:
-    # noinspection PyProtectedMember
-    from typing import dataclass_transform
-except ImportError:
-    from typing_extensions import dataclass_transform
+# Typing is also a slow import, so we use the dataclass_transform
+# function copied from the module instead
+TYPING_IS_SLOW = True
+if TYPING_IS_SLOW:
+    from .._typing import dataclass_transform
+else:
+    try:
+        # noinspection PyProtectedMember
+        from typing import dataclass_transform
+    except ImportError:
+        from typing_extensions import dataclass_transform
 
 from ._attribute_class import Attribute
 from ..constants import (
@@ -297,8 +303,6 @@ def _make_prefab(
     return cls
 
 
-# Pycharm has incorrect arguments for this.
-# noinspection PyArgumentList
 @dataclass_transform(field_specifiers=(attribute,))
 def prefab(
     cls: type = None,

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -24,9 +24,13 @@
 Handle boilerplate generation for classes.
 """
 import sys
-import inspect
 import warnings
 from functools import partial
+
+# Inspect is a slow import, it's only used for pre/post init
+# functions, if those aren't used there's no need for it
+# So now it's imported only when analyzing those functions
+# import inspect
 
 try:
     # noinspection PyProtectedMember
@@ -227,6 +231,7 @@ def _make_prefab(
     except AttributeError:
         pass
     else:
+        import inspect
         signature = inspect.signature(func)
         for item in signature.parameters.keys():
             if item not in attributes.keys() and item != "self":
@@ -240,6 +245,7 @@ def _make_prefab(
     except AttributeError:
         pass
     else:
+        import inspect
         signature = inspect.signature(func)
         for item in signature.parameters.keys():
             if item != "self":

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -34,8 +34,8 @@ from functools import partial
 
 # Typing is also a slow import, so we use the dataclass_transform
 # function copied from the module instead
-TYPING_IS_SLOW = True
-if TYPING_IS_SLOW:
+SLOW_TYPING = True
+if SLOW_TYPING:
     from .._typing import dataclass_transform
 else:
     try:

--- a/src/prefab_classes/funcs.py
+++ b/src/prefab_classes/funcs.py
@@ -1,9 +1,12 @@
 from collections.abc import Container
-from typing import Optional, Callable
 from functools import lru_cache, partial
 
 from .constants import FIELDS_ATTRIBUTE
 from .exceptions import PrefabTypeError
+
+# noinspection PyUnreachableCode
+if False:
+    from typing import Optional, Callable
 
 
 def is_prefab(o):
@@ -52,7 +55,7 @@ def _as_dict_cache(cls, excludes=None):
     return method
 
 
-def as_dict(inst, *, excludes: Optional[tuple[str, ...]] = None):
+def as_dict(inst, *, excludes: "Optional[tuple[str, ...]]" = None):
     """
     Represent the prefab as a dictionary of attribute names and values.
     Exclude any keys listed in `excludes`
@@ -66,7 +69,7 @@ def as_dict(inst, *, excludes: Optional[tuple[str, ...]] = None):
     return _as_dict_cache(inst.__class__, excludes)(inst)
 
 
-def as_dict_uncached(inst, *, excludes: Optional[Container[str]] = None):
+def as_dict_uncached(inst, *, excludes: "Optional[Container[str]]" = None):
     """
     Represent the prefab as a dictionary of attribute names and values.
     Exclude any keys listed in `excludes`
@@ -93,8 +96,8 @@ def as_dict_uncached(inst, *, excludes: Optional[Container[str]] = None):
 def to_json(
         inst,
         *,
-        excludes: Optional[tuple[str, ...]] = None,
-        dumps_func: Callable = None,
+        excludes: "Optional[tuple[str, ...]]" = None,
+        dumps_func: "Callable" = None,
         **kwargs
 ) -> str:
     """


### PR DESCRIPTION
Some of the modules used in parts of `prefab_classes` are noticeably slow to import.

Three modules in particular take up most of the import time.

---

`ast` was being imported as it's used to unparse for the preview functions and for generating the `compiled` form. The compilation steps were already lazily imported (as that code should only run on initial compilation) but for the preview/source generation it was imported at the top - this is moved to inside the function.

`inspect` is used in the `dynamic` classes to handle finding the arguments in the pre/post init functions. If prefabs don't provide those functions it isn't needed so now it is only imported just before use.

`typing` was used for type hints in a few places, it's quite an expensive import. Mostly this has been worked around but it did involve making a copy of the `dataclass_transform` decorator, losing a few basic type hints and converting some others to strings.

Some of the typing hacks can be removed when this stops supporting python 3.9 as from 3.10 union types can be written using `|`. The only reason 3.9 is supported is because that's the latest version of python provided by pypy.

---

Removing these imports takes the import time of the module down from ~20ms to ~3ms. For comparison dataclasses takes ~16ms and attrs takes ~35ms. 

This is the result of `python -X importtime -c "import prefab_classes"` on v0.7.5 on the macbook I'm using for development.

```
import time: self [us] | cumulative | imported package
import time:       172 |        172 |   _io
import time:        36 |         36 |   marshal
import time:       288 |        288 |   posix
import time:       326 |        820 | _frozen_importlib_external
import time:       612 |        612 |   time
import time:       124 |        736 | zipimport
import time:        52 |         52 |     _codecs
import time:       336 |        388 |   codecs
import time:       647 |        647 |   encodings.aliases
import time:       823 |       1857 | encodings
import time:       266 |        266 | encodings.utf_8
import time:        92 |         92 | _signal
import time:        50 |         50 |     _abc
import time:       130 |        180 |   abc
import time:       169 |        348 | io
import time:        47 |         47 |       _stat
import time:        55 |        102 |     stat
import time:       771 |        771 |     _collections_abc
import time:        35 |         35 |       genericpath
import time:        59 |         93 |     posixpath
import time:       299 |       1264 |   os
import time:        69 |         69 |   _sitebuiltins
import time:       796 |        796 |   _distutils_hack
import time:      1245 |       1245 |   types
import time:       494 |        494 |       warnings
import time:       406 |        900 |     importlib
import time:       437 |        437 |     importlib._abc
import time:       130 |        130 |         itertools
import time:       236 |        236 |         keyword
import time:        78 |         78 |           _operator
import time:       354 |        432 |         operator
import time:       231 |        231 |         reprlib
import time:        73 |         73 |         _collections
import time:      1430 |       2529 |       collections
import time:        64 |         64 |         _functools
import time:       627 |        691 |       functools
import time:      1049 |       4268 |     contextlib
import time:       155 |       5758 |   importlib.util
import time:        67 |         67 |   importlib.machinery
import time:       182 |        182 |   sitecustomize
import time:      5731 |      15109 | site
import time:      1071 |       1071 |           _ast
import time:      1822 |       1822 |           enum
import time:      2274 |       5166 |         ast
import time:       383 |        383 |             _opcode
import time:       596 |        978 |           opcode
import time:      1365 |       2343 |         dis
import time:       245 |        245 |         collections.abc
import time:        71 |         71 |                 _sre
import time:       343 |        343 |                   re._constants
import time:       748 |       1091 |                 re._parser
import time:       194 |        194 |                 re._casefix
import time:       407 |       1762 |               re._compiler
import time:       336 |        336 |               copyreg
import time:       700 |       2797 |             re
import time:       239 |        239 |             token
import time:      1151 |       4186 |           tokenize
import time:       212 |       4397 |         linecache
import time:      1791 |      13940 |       inspect
import time:       415 |        415 |         _typing
import time:      2920 |       3335 |       typing
import time:       141 |        141 |         prefab_classes.sentinels
import time:       173 |        173 |         prefab_classes.exceptions
import time:       236 |        549 |       prefab_classes.dynamic._attribute_class
import time:       122 |        122 |       prefab_classes.constants
import time:       208 |        208 |         prefab_classes.dynamic.autogen
import time:       222 |        430 |       prefab_classes.dynamic.method_generators
import time:       284 |      18657 |     prefab_classes.dynamic.prefab
import time:       196 |      18853 |   prefab_classes.dynamic
import time:       296 |        296 |     prefab_classes.compiled.import_hook
import time:       175 |        175 |     prefab_classes.compiled.rewrite_source
import time:       151 |        621 |   prefab_classes.compiled
import time:       218 |        218 |   prefab_classes.funcs
import time:       320 |      20012 | prefab_classes
```

And with the `inspect` and `ast` imports delayed to only occur where they are used and the 
`typing` import removed entirely.

```
import time: self [us] | cumulative | imported package
import time:       173 |        173 |   _io
import time:        36 |         36 |   marshal
import time:       291 |        291 |   posix
import time:       322 |        820 | _frozen_importlib_external
import time:       622 |        622 |   time
import time:       112 |        734 | zipimport
import time:        51 |         51 |     _codecs
import time:       311 |        361 |   codecs
import time:       666 |        666 |   encodings.aliases
import time:       760 |       1786 | encodings
import time:       270 |        270 | encodings.utf_8
import time:        89 |         89 | _signal
import time:        36 |         36 |     _abc
import time:       129 |        165 |   abc
import time:       169 |        334 | io
import time:        52 |         52 |       _stat
import time:        57 |        109 |     stat
import time:       804 |        804 |     _collections_abc
import time:        37 |         37 |       genericpath
import time:        66 |        102 |     posixpath
import time:       323 |       1337 |   os
import time:        84 |         84 |   _sitebuiltins
import time:       877 |        877 |   _distutils_hack
import time:      1042 |       1042 |   types
import time:       359 |        359 |       warnings
import time:       343 |        702 |     importlib
import time:       306 |        306 |     importlib._abc
import time:       110 |        110 |         itertools
import time:       185 |        185 |         keyword
import time:        88 |         88 |           _operator
import time:       353 |        441 |         operator
import time:       242 |        242 |         reprlib
import time:        70 |         70 |         _collections
import time:      1045 |       2089 |       collections
import time:        66 |         66 |         _functools
import time:       609 |        674 |       functools
import time:       708 |       3470 |     contextlib
import time:       148 |       4624 |   importlib.util
import time:        66 |         66 |   importlib.machinery
import time:       142 |        142 |   sitecustomize
import time:      6453 |      14623 | site
import time:       119 |        119 |       prefab_classes._typing
import time:       133 |        133 |         prefab_classes.sentinels
import time:       168 |        168 |         prefab_classes.exceptions
import time:       162 |        462 |       prefab_classes.dynamic._attribute_class
import time:       119 |        119 |       prefab_classes.constants
import time:       115 |        115 |         prefab_classes.dynamic.autogen
import time:       220 |        334 |       prefab_classes.dynamic.method_generators
import time:       252 |       1284 |     prefab_classes.dynamic.prefab
import time:       193 |       1477 |   prefab_classes.dynamic
import time:       272 |        272 |     prefab_classes.compiled.import_hook
import time:       146 |        146 |     prefab_classes.compiled.rewrite_source
import time:       147 |        564 |   prefab_classes.compiled
import time:       219 |        219 |     collections.abc
import time:       172 |        390 |   prefab_classes.funcs
import time:       330 |       2760 | prefab_classes
```