### PR TITLE
More import time improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class Settings:
 In either case the result behaves the same.
 
 ```python
->>> from prefab_classes import to_json
+>>> from prefab_classes.funcs import to_json
 >>> s = Settings()
 >>> print(s)
 Settings(hostname='localhost', template_folder='base/path', template_name='index')
@@ -155,7 +155,7 @@ class SettingsPath:
 Direct import using prefab_compiler
 
 ```python
-from prefab_classes import prefab_compiler
+from prefab_classes.compiled import prefab_compiler
 
 with prefab_compiler():
     from example import SettingsPath

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,10 +13,10 @@
 ## Helper functions ##
 
 ```{eval-rst}
-.. autofunction:: prefab_classes::is_prefab
-.. autofunction:: prefab_classes::is_prefab_instance
-.. autofunction:: prefab_classes::as_dict
-.. autofunction:: prefab_classes::to_json
+.. autofunction:: prefab_classes.funcs::is_prefab
+.. autofunction:: prefab_classes.funcs::is_prefab_instance
+.. autofunction:: prefab_classes.funcs::as_dict
+.. autofunction:: prefab_classes.funcs::to_json
 ```
 
 ## Compilation functions ##
@@ -24,7 +24,7 @@
 ### Import hook handler ###
 
 ```{eval-rst}
-.. autofunction:: prefab_classes::prefab_compiler
+.. autoclass:: prefab_classes.compiled::prefab_compiler
 ```
 
 ### Previewer and .py unparser ###

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -85,7 +85,7 @@ class SettingsPath:
 Compiled prefabs can be used directly on import by using the prefab_compiler.
 
 ```python
-from prefab_classes import prefab_compiler
+from prefab_classes.compiled import prefab_compiler
 
 with prefab_compiler():
     from example import SettingsPath

--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -2,7 +2,4 @@ __version__ = "v0.7.6"
 PREFAB_MAGIC_BYTES = b"_".join([b"PREFAB_CLASSES", __version__.encode()])
 
 from .dynamic import prefab, attribute
-from .compiled import prefab_compiler
-from .exceptions import PrefabError
-from .funcs import is_prefab, is_prefab_instance, to_json, as_dict
 from .sentinels import KW_ONLY

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -25,7 +25,14 @@ Handle boilerplate generation for classes.
 """
 import sys
 import warnings
-from functools import partial
+
+# Import speed optimization
+# The C implementation can import nearly 100x faster
+# and will usually be available.
+try:
+    from _functools import partial
+except ImportError:
+    from functools import partial
 
 # Inspect is a slow import, it's only used for pre/post init
 # functions, if those aren't used there's no need for it
@@ -340,6 +347,8 @@ def prefab(
     """
     if not cls:
         # Called as () method to change defaults
+        # Skip compile arguments other than prefab/fallback
+        # These are not needed
         return partial(
             prefab,
             init=init,

--- a/tests/compiled/test_import_compile.py
+++ b/tests/compiled/test_import_compile.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefab_classes import prefab_compiler
+from prefab_classes.compiled import prefab_compiler
 from prefab_classes.exceptions import CompiledPrefabError
 
 

--- a/tests/compiled/test_importhook.py
+++ b/tests/compiled/test_importhook.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from prefab_classes import prefab_compiler
+from prefab_classes.compiled import prefab_compiler
 from prefab_classes.compiled.import_hook import PrefabFinder, PrefabHacker
 
 

--- a/tests/compiled/test_rewrite_py.py
+++ b/tests/compiled/test_rewrite_py.py
@@ -1,5 +1,4 @@
 from prefab_classes.compiled import rewrite_to_py
-import os
 from pathlib import Path
 
 # Don't include the version number for this test.

--- a/tests/compiled/test_slots.py
+++ b/tests/compiled/test_slots.py
@@ -1,5 +1,5 @@
 import pytest
-from prefab_classes import prefab_compiler
+from prefab_classes.compiled import prefab_compiler
 
 
 @pytest.mark.usefixtures("compile_folder_modules")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefab_classes import prefab_compiler
+from prefab_classes.compiled import prefab_compiler
 
 
 @pytest.fixture(params=[True, False], ids=["Compiled", "Live"])

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -1,5 +1,5 @@
 """Tests for errors raised on class creation"""
-from prefab_classes import PrefabError
+from prefab_classes.exceptions import PrefabError
 from prefab_classes.constants import FIELDS_ATTRIBUTE
 
 import pytest

--- a/tests/shared/test_serialization.py
+++ b/tests/shared/test_serialization.py
@@ -1,7 +1,7 @@
 """Tests related to serialization to JSON or Pickle"""
 from pathlib import PurePosixPath, PurePath
 
-from prefab_classes import as_dict, to_json
+from prefab_classes.funcs import as_dict, to_json
 from pytest import raises
 
 


### PR DESCRIPTION
By removing some of the imports from the main __init__ the import performance is improved. This means if the compiled or funcs submodules aren't used then you no longer pay for the import time. These modules import slower stdlib modules so make them opt-in. It's a little more cumbersome to use, but not dramatically.

The main module now imports `partial` directly from the C implementation if it is available avoiding the slow import of the python module in most cases. I'm not sure this is a good pattern, but the `functools` import takes longer than the entire module does now.

# Hyperfine Tests #

`hyperfine --warmup 3 'python -c "import prefab_classes"'`

This branch:
```
Benchmark 1: python -c "import prefab_classes"
  Time (mean ± σ):      28.3 ms ±   1.9 ms    [User: 17.6 ms, System: 7.5 ms]
  Range (min … max):    25.6 ms …  36.1 ms    87 runs
```

Main:
```
Benchmark 1: python -c "import prefab_classes"
  Time (mean ± σ):      33.9 ms ±   1.5 ms    [User: 21.8 ms, System: 8.7 ms]
  Range (min … max):    31.5 ms …  39.0 ms    75 runs
```

## Other module comparisons ##

```
Benchmark 1: python -c "import prefab_classes"
  Time (mean ± σ):      29.0 ms ±   3.2 ms    [User: 17.7 ms, System: 7.9 ms]
  Range (min … max):    25.5 ms …  40.9 ms    94 runs
 
Benchmark 2: python -c "import dataclasses"
  Time (mean ± σ):      47.5 ms ±   3.9 ms    [User: 33.0 ms, System: 10.8 ms]
  Range (min … max):    42.5 ms …  59.7 ms    60 runs
 
Benchmark 3: python -c "import attrs"
  Time (mean ± σ):      66.6 ms ±   1.4 ms    [User: 49.8 ms, System: 12.9 ms]
  Range (min … max):    64.7 ms …  70.8 ms    42 runs
 
Summary
  'python -c "import prefab_classes"' ran
    1.64 ± 0.23 times faster than 'python -c "import dataclasses"'
    2.30 ± 0.26 times faster than 'python -c "import attrs"'
```

# Python importtime tests #

`python -X importtime -c "import prefab_classes"`

Import time detail:
```
import time: self [us] | cumulative | imported package
import time:       321 |        321 |   _io
import time:        80 |         80 |   marshal
import time:       495 |        495 |   posix
import time:       453 |       1347 | _frozen_importlib_external
import time:       778 |        778 |   time
import time:       264 |       1042 | zipimport
import time:        54 |         54 |     _codecs
import time:       342 |        395 |   codecs
import time:       653 |        653 |   encodings.aliases
import time:      1017 |       2064 | encodings
import time:       267 |        267 | encodings.utf_8
import time:        90 |         90 | _signal
import time:        35 |         35 |     _abc
import time:       125 |        159 |   abc
import time:       179 |        338 | io
import time:        49 |         49 |       _stat
import time:        59 |        107 |     stat
import time:       818 |        818 |     _collections_abc
import time:        35 |         35 |       genericpath
import time:        60 |         94 |     posixpath
import time:       319 |       1337 |   os
import time:        66 |         66 |   _sitebuiltins
import time:       672 |        672 |   _distutils_hack
import time:       157 |        157 |   sitecustomize
import time:      1705 |       3936 | site
import time:       394 |        394 |       warnings
import time:        63 |         63 |       _functools
import time:       140 |        140 |       prefab_classes._typing
import time:       152 |        152 |         prefab_classes.sentinels
import time:       205 |        205 |         prefab_classes.exceptions
import time:       219 |        575 |       prefab_classes.dynamic._attribute_class
import time:       127 |        127 |       prefab_classes.constants
import time:       127 |        127 |         prefab_classes.dynamic.autogen
import time:       238 |        365 |       prefab_classes.dynamic.method_generators
import time:       312 |       1973 |     prefab_classes.dynamic.prefab
import time:       339 |       2311 |   prefab_classes.dynamic
import time:       322 |       2633 | prefab_classes
```

Main:
```
import time: self [us] | cumulative | imported package
import time:       194 |        194 |   _io
import time:        38 |         38 |   marshal
import time:       323 |        323 |   posix
import time:       364 |        918 | _frozen_importlib_external
import time:       710 |        710 |   time
import time:       185 |        895 | zipimport
import time:        88 |         88 |     _codecs
import time:       522 |        610 |   codecs
import time:       785 |        785 |   encodings.aliases
import time:      1302 |       2695 | encodings
import time:       282 |        282 | encodings.utf_8
import time:        93 |         93 | _signal
import time:        36 |         36 |     _abc
import time:       133 |        169 |   abc
import time:       176 |        344 | io
import time:        50 |         50 |       _stat
import time:        59 |        109 |     stat
import time:       831 |        831 |     _collections_abc
import time:        36 |         36 |       genericpath
import time:        63 |         99 |     posixpath
import time:       308 |       1345 |   os
import time:        66 |         66 |   _sitebuiltins
import time:       683 |        683 |   _distutils_hack
import time:       160 |        160 |   sitecustomize
import time:      1739 |       3990 | site
import time:       413 |        413 |       warnings
import time:       114 |        114 |           itertools
import time:       213 |        213 |           keyword
import time:        79 |         79 |             _operator
import time:       371 |        450 |           operator
import time:       262 |        262 |           reprlib
import time:        66 |         66 |           _collections
import time:      1061 |       2163 |         collections
import time:       348 |        348 |         types
import time:        62 |         62 |         _functools
import time:       683 |       3254 |       functools
import time:       156 |        156 |       prefab_classes._typing
import time:       152 |        152 |         prefab_classes.sentinels
import time:       186 |        186 |         prefab_classes.exceptions
import time:       179 |        517 |       prefab_classes.dynamic._attribute_class
import time:       130 |        130 |       prefab_classes.constants
import time:       129 |        129 |         prefab_classes.dynamic.autogen
import time:       350 |        479 |       prefab_classes.dynamic.method_generators
import time:       327 |       5272 |     prefab_classes.dynamic.prefab
import time:       334 |       5606 |   prefab_classes.dynamic
import time:       641 |        641 |       contextlib
import time:       253 |        253 |         importlib
import time:        66 |        319 |       importlib.machinery
import time:       266 |        266 |         importlib._abc
import time:       121 |        387 |       importlib.util
import time:       325 |       1670 |     prefab_classes.compiled.import_hook
import time:       169 |        169 |     prefab_classes.compiled.rewrite_source
import time:       166 |       2004 |   prefab_classes.compiled
import time:       219 |        219 |     collections.abc
import time:       206 |        424 |   prefab_classes.funcs
import time:       344 |       8377 | prefab_classes
```