### PR TITLE
Add faster to_json function using cached encoders.

### DIFF
--- a/src/prefab_classes/exceptions.py
+++ b/src/prefab_classes/exceptions.py
@@ -33,9 +33,5 @@ class CompiledPrefabError(PrefabError):
     pass
 
 
-class PrefabTypeError(PrefabError, TypeError):
-    pass
-
-
 class FrozenPrefabError(PrefabError):
     pass

--- a/src/prefab_classes/funcs.py
+++ b/src/prefab_classes/funcs.py
@@ -1,8 +1,6 @@
-from collections.abc import Container
 from functools import lru_cache, partial
 
 from .constants import FIELDS_ATTRIBUTE
-from .exceptions import PrefabTypeError
 
 # noinspection PyUnreachableCode
 if False:
@@ -41,7 +39,7 @@ def _as_dict_cache(cls, excludes=None):
     try:
         attrib_names = getattr(cls, FIELDS_ATTRIBUTE)
     except AttributeError:
-        raise PrefabTypeError(f"inst should be a prefab instance, not {cls}")
+        raise TypeError(f"inst should be a prefab instance, not {cls}")
 
     if excludes:
         vals = ", ".join(f"'{item}': obj.{item}" for item in attrib_names if item not in excludes)
@@ -66,31 +64,42 @@ def as_dict(inst, *, excludes: "Optional[tuple[str, ...]]" = None):
     :param excludes: tuple of field names to exclude from the resulting dict
     :return: dictionary {attribute_name: attribute_value, ...}
     """
-    return _as_dict_cache(inst.__class__, excludes)(inst)
+    return _as_dict_cache(type(inst), excludes)(inst)
 
 
-def as_dict_uncached(inst, *, excludes: "Optional[Container[str]]" = None):
-    """
-    Represent the prefab as a dictionary of attribute names and values.
-    Exclude any keys listed in `excludes`
-
-    This **does not** recurse.
-
-    :param inst: instance of prefab class
-    :param excludes: collection of values to exclude from the resulting dict
-    :return: dictionary {attribute_name: attribute_value, ...}
-    """
+def _as_dict_json_wrapper(inst, *, excludes: "Optional[tuple[str, ...]]" = None):
+    """Wrapper that gives a more accurate TypeError message for serialization"""
     try:
-        attrib_names = getattr(inst, FIELDS_ATTRIBUTE)
-    except AttributeError:
-        raise PrefabTypeError(f"inst should be a prefab instance, not {type(inst)}")
+        return _as_dict_cache(type(inst), excludes)(inst)
+    except TypeError:
+        raise TypeError(f"Object of type {type(inst).__name__} is not JSON serializable")
 
-    if not excludes:
-        result = {name: getattr(inst, name) for name in attrib_names}
-    else:
-        excludes = excludes or set()
-        result = {name: getattr(inst, name) for name in attrib_names if name not in excludes}
-    return result
+
+@lru_cache
+def _get_json_encoder(excludes: "Optional[tuple[str, ...]]" = None):
+    import json
+    return json.JSONEncoder(default=partial(_as_dict_json_wrapper, excludes=excludes))
+
+
+@lru_cache
+def _merge_defaults(*defaults):
+    """
+    Combine multiple default functions into one.
+
+    Default functions are expected to return serializable objects or raise a TypeError
+
+    :param defaults: 'default' functions for json.dumps
+    :return: merged default function
+    """
+    def default(o):
+        for func in defaults:
+            try:
+                return func(o)
+            except TypeError:
+                pass
+        else:
+            raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+    return default
 
 
 def to_json(
@@ -103,10 +112,7 @@ def to_json(
     """
     Output the class attributes as JSON
 
-    This is essentially a wrapper around any `dumps` function provided.
-    The main advantage is it will let you pass an additional 'default'
-    function into the default argument and it makes it easier to use
-    excludes.
+    If no dumps function it will attempt to reuse the basic encoder
 
     :param inst: instance of prefab class
     :param excludes: tuple of attribute names to exclude from json
@@ -117,25 +123,20 @@ def to_json(
     :param kwargs: keyword arguments passed directly to dumps_func
     :return: String of JSON data from the class attributes
     """
+    if dumps_func is None and not kwargs:
+        encoder = _get_json_encoder(excludes)
+        return encoder.encode(inst)
+    else:
+        default = kwargs.pop('default', None)
 
-    as_dict_excludes = partial(as_dict, excludes=excludes)
+        if dumps_func is None:
+            import json
+            dumps_func = json.dumps
 
-    default = kwargs.pop('default', None)
+        as_dict_excludes = partial(as_dict, excludes=excludes)
 
-    # This function tells the JSON encoder how to serialise Prefab derived objects
-    # If the user needs to serialize other classes their default will be called
-    # only if the object is not an instance of Prefab
-    def default_func(o):
-        if is_prefab_instance(o):
-            return as_dict_excludes(o)
-        elif default is not None:
-            return default(o)
-        raise TypeError(
-            f"Object of type {o.__class__.__name__} is not JSON Serializable"
-        )
-
-    if dumps_func is None:
-        import json  # Only import JSON if needed
-        dumps_func = json.dumps
-
-    return dumps_func(inst, default=default_func, **kwargs)
+        if default is None:
+            return dumps_func(inst, default=as_dict_excludes, **kwargs)
+        else:
+            default_func = _merge_defaults(as_dict_excludes, default)
+            return dumps_func(inst, default=default_func, **kwargs)

--- a/tests/shared/test_serialization.py
+++ b/tests/shared/test_serialization.py
@@ -28,12 +28,12 @@ def test_tojson(importer):
     assert as_dict(pth)["path"] == PurePosixPath("path/to/test")
 
     expected_json = json.dumps(
-        {"filename": "testfile", "path": "path/to/test"}, indent=2
+        {"filename": "testfile", "path": "path/to/test"}
     )
-    assert to_json(pth, default=str, indent=2) == expected_json
+    assert to_json(pth, default=str) == expected_json
 
-    expected_json = json.dumps({"path": "path/to/test"}, indent=2)
-    assert to_json(pth, excludes=("filename",), default=str, indent=2) == expected_json
+    expected_json = json.dumps({"path": "path/to/test"})
+    assert to_json(pth, excludes=("filename",), default=str) == expected_json
 
 
 def test_tojson_recurse(importer):
@@ -46,9 +46,9 @@ def test_tojson_recurse(importer):
 
     circ_dict = {"radius": 1, "origin": {"x": 0, "y": 0}}
 
-    circ_json = json.dumps(circ_dict, indent=2)
+    circ_json = json.dumps(circ_dict)
 
-    assert circ_json == to_json(circ, indent=2)
+    assert circ_json == to_json(circ)
 
 
 def test_jsonencoder_failure(importer):


### PR DESCRIPTION
The previous to_json function used json.dumps and constructed a new default function for every use.

The new version uses cached encoders and functions if possible and will fall back to dumps if not.