### PR TITLE
Replace use of inspect with direct analysis of the __code__ object

### DIFF
--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -39,9 +39,6 @@
 # greater good.
 # ----------------------------------------------------------------------
 
-# inspect is now imported lazily when needed as it is a slow import.
-# import inspect
-
 from ..constants import (
     PRE_INIT_FUNC,
     POST_INIT_FUNC,
@@ -122,11 +119,14 @@ def get_init_maker(*, init_name="__init__"):
         ]:
             try:
                 func = getattr(cls, func_name)
+                func_code = func.__code__
             except AttributeError:
                 pass
             else:
-                import inspect
-                for item in inspect.signature(func).parameters.keys():
+                argcount = func_code.co_argcount + func_code.co_kwonlyargcount
+                arglist = func_code.co_varnames[:argcount]
+
+                for item in arglist:
                     if item != "self":
                         func_arglist.append(item)
 


### PR DESCRIPTION
`inspect` is a very slow module to import relative to the import time of `prefab_classes` but was used to get the argument signatures of pre_init and post_init functions. 

`prefab_classes` imports in ~3ms, `inspect` imports in ~18ms.

This PR replaces that with direct use of the __code__ object (which is how `inspect.signature` works) avoiding the heavy import at runtime.