### PR TITLE
Remove typing_extensions dependency.

### DIFF
--- a/perf/perf_profile.py
+++ b/perf/perf_profile.py
@@ -15,14 +15,6 @@ import platform
 from collections import namedtuple
 from typing import NamedTuple
 
-try:
-    import attrs
-except ImportError:
-    pass
-try:
-    import pydantic
-except ImportError:
-    pass
 
 import dataclasses
 import cluegen
@@ -265,12 +257,14 @@ def main(reps, test_everything=False, exclude_compile=False):
         run_test('dataclasses', reps, exclude_compile=exclude_compile)
 
         try:
+            import attrs
             write_perftemp(100, attr_template, 'from attrs import define\n')
             run_test(f'attrs {attrs.__version__}', reps, exclude_compile=exclude_compile)
         except ImportError:
             print("attrs not installed")
 
         try:
+            import pydantic
             write_perftemp(100, pydantic_template, 'from pydantic import BaseModel\n')
             run_test(f'pydantic {pydantic.__version__}', reps, exclude_compile=exclude_compile)
         except ImportError:
@@ -305,9 +299,9 @@ def main(reps, test_everything=False, exclude_compile=False):
     write_perftemp(100, compiled_prefab_template, compiled_prefab_import)
     run_test(f'compiled_prefab {prefab_classes.__version__}', reps, exclude_compile=exclude_compile)
 
-    write_perftemp(100, compiled_prefab_template, compiled_prefab_import)
-    run_test(f'compiled_prefab_nocache {prefab_classes.__version__}', reps, exclude_compile=False,
-             clear_cache=True)
+    # write_perftemp(100, compiled_prefab_template, compiled_prefab_import)
+    # run_test(f'compiled_prefab_nocache {prefab_classes.__version__}', reps, exclude_compile=False,
+    #          clear_cache=True)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dynamic = ['version']
-dependencies = [
-    "typing_extensions; python_version < '3.11'"
-]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -34,17 +34,15 @@ try:
 except ImportError:
     from functools import partial
 
-# Typing is also a slow import, so we use the dataclass_transform
-# function copied from the module instead
+# Typing is a slow import so the 'dataclass_transform' code is copied
+# into a separate file. This also provides 3.9/3.10 support without
+# needing to install typing_extensions.
+# If typing ever becomes fast to import we can use the code from the right place.
 SLOW_TYPING = True
 if SLOW_TYPING:
     from .._typing import dataclass_transform
 else:
-    try:
-        # noinspection PyProtectedMember
-        from typing import dataclass_transform
-    except ImportError:
-        from typing_extensions import dataclass_transform
+    from typing import dataclass_transform
 
 from ._attribute_class import Attribute
 from ..constants import (


### PR DESCRIPTION
`typing_extensions` was added as a dependency to provide `dataclass_transform` for python 3.9/3.10.

When the code for `dataclass_transform` was copied into an internal module to make import faster this dependency became unnecessary and so can be removed.