### PR TITLE
Fix a missing newline in dynamic templates when using post_init

### DIFF
--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -150,7 +150,7 @@ def get_init_maker(*, init_name="__init__"):
                 value = f"_{name}_converter({value})"
 
             if name in post_init_args:
-                if attrib.default_factory or attrib.converter:
+                if attrib.default_factory is not NOTHING or attrib.converter:
                     processes.append((name, value))
             else:
                 assignments.append((name, value))
@@ -166,6 +166,7 @@ def get_init_maker(*, init_name="__init__"):
             body += "\n".join(
                 f"    self.{name} = {value}" for name, value in assignments
             )
+            body += "\n"
             body += "\n".join(f"    {name} = {value}" for name, value in processes)
         else:
             body = "    pass"

--- a/tests/shared/examples/init_ex.py
+++ b/tests/shared/examples/init_ex.py
@@ -79,6 +79,17 @@ class ExcludeField:
 
 
 @prefab(compile_prefab=True, compile_fallback=True)
+class PostInitPartial:
+    x: int
+    y: int
+    z: list[int] = attribute(default_factory=list)
+
+    def __prefab_post_init__(self, z):
+        z.append(1)
+        self.z = z
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
 class EmptyContainers:
     x: list = attribute(default_factory=list)
     y: set = attribute(default_factory=set)

--- a/tests/shared/test_init.py
+++ b/tests/shared/test_init.py
@@ -112,6 +112,13 @@ def test_pre_post_init_arguments(importer):
         y = PrePostInitArguments(2, 1)
 
 
+def test_post_init_partial(importer):
+    from init_ex import PostInitPartial
+    x = PostInitPartial(1, 2)
+
+    assert (x.x, x.y, x.z) == (1, 2, [1])
+
+
 def test_exclude_field(importer):
     from init_ex import ExcludeField
 


### PR DESCRIPTION
If values were sent to post init and also assigned in __init__ a newline would be missing between the assignments causing a syntax error.