### PR TITLE
Backup imports if frozen imports fail.

### DIFF
--- a/src/prefab_classes_hook/__init__.py
+++ b/src/prefab_classes_hook/__init__.py
@@ -1,4 +1,8 @@
 __version__ = "v0.9.1"
 PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.1"
 
-from .import_hook import prefab_compiler, insert_prefab_importhook, remove_prefab_importhook
+from .import_hook import (
+    prefab_compiler,
+    insert_prefab_importhook,
+    remove_prefab_importhook,
+)


### PR DESCRIPTION
Generally they should work, but this will backup to regular _bootstrap_external if they don't. If that doesn't work I don't have sources for some of the other internal stuff.