### PR TITLE
Use type hints from post_init in init if provided

### DIFF
--- a/src/prefab_classes/compiled/generator.py
+++ b/src/prefab_classes/compiled/generator.py
@@ -947,7 +947,7 @@ class PrefabDetails:
             body.append(self.frozen_setattr_method)
             body.append(self.frozen_delattr_method)
 
-        # Add functions andd definitions to the body
+        # Add functions and definitions to the body
         # Remove the @prefab decorator
         # Check if a class starts with what we assume is a docstring.
         if (

--- a/src/prefab_classes/compiled/generator.py
+++ b/src/prefab_classes/compiled/generator.py
@@ -494,10 +494,7 @@ class PrefabDetails:
                 assignment_value = ast.Name(id=field.name, ctx=ast.Load())
                 if field.default or field.default_factory:
                     # Include the annotation if this is an annotated value
-                    if hasattr(field, "annotation"):
-                        arg = ast.arg(arg=field.name, annotation=field.annotation)
-                    else:
-                        arg = ast.arg(arg=field.name)
+                    arg = ast.arg(arg=field.name, annotation=field.annotation)
 
                     # For regular defaults, assign in the signature as expected
                     if field.default:
@@ -535,10 +532,8 @@ class PrefabDetails:
                         raise SyntaxError(
                             "non-default argument follows default argument"
                         )
-                    if field.annotation:
-                        arg = ast.arg(arg=field.name, annotation=field.annotation)
-                    else:
-                        arg = ast.arg(arg=field.name)
+
+                    arg = ast.arg(arg=field.name, annotation=field.annotation)
 
                     if field.kw_only:
                         kw_defaults.append(None)

--- a/src/prefab_classes/dynamic/autogen.py
+++ b/src/prefab_classes/dynamic/autogen.py
@@ -52,7 +52,6 @@ def autogen(func, globs=None):
     globs = globs if globs is not None else {}
 
     def __get__(self, instance, cls):
-        # Include the defaultvalue class used as a placeholder for defaults
         local_vars = {}
         code = func(cls)
         exec(code, globs, local_vars)

--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -255,7 +255,7 @@ def get_frozen_setattr_maker():
         field_names = getattr(cls, FIELDS_ATTRIBUTE)
 
         # Make the fields set literal
-        fields_delimited = ", ".join(f"'{field}'" for field in field_names)
+        fields_delimited = ", ".join(f"{field!r}" for field in field_names)
         field_set = f"{{ {fields_delimited} }}"
 
         # Dynamic prefabs are not slotted so it is possible to insert into the dict

--- a/tests/shared/examples/init_ex.py
+++ b/tests/shared/examples/init_ex.py
@@ -1,6 +1,7 @@
 # COMPILE_PREFABS
 from prefab_classes import prefab, attribute
 from pathlib import Path
+from typing import Union
 
 
 @prefab(compile_prefab=True, compile_fallback=True)
@@ -87,6 +88,15 @@ class PostInitPartial:
     def __prefab_post_init__(self, z):
         z.append(1)
         self.z = z
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class PostInitAnnotations:
+    x: int
+    y: Path
+
+    def __prefab_post_init__(self, y: Union[str, Path]):
+        self.y = Path(y)
 
 
 @prefab(compile_prefab=True, compile_fallback=True)

--- a/tests/shared/test_init.py
+++ b/tests/shared/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the behaviour of __init__"""
 import sys
 from pathlib import Path
+from typing import Union
 
 import pytest
 
@@ -118,6 +119,17 @@ def test_post_init_partial(importer):
     x = PostInitPartial(1, 2)
 
     assert (x.x, x.y, x.z) == (1, 2, [1])
+
+
+def test_post_init_annotations(importer):
+    from init_ex import PostInitAnnotations
+
+    x = PostInitAnnotations(1, '/usr/bin/python')
+
+    init_annotations = PostInitAnnotations.__init__.__annotations__
+
+    assert init_annotations['x'] == int
+    assert init_annotations['y'] == Union[str, Path]
 
 
 def test_exclude_field(importer):


### PR DESCRIPTION
If an argument is type hinted in `__prefab_post_init__` this type hint will now be used in `__init__` instead of the class type hint.

eg:

```python
from pathlib import Path
from prefab_classes import prefab

@prefab
class FilePath:
    pth: Path

    def __prefab_post_init__(self, pth: str | Path):
        self.pth = Path(pth)
```

Will now generate

```python
class FilePath:
    ...
    pth: Path

    def __init__(self, pth: str | Path):
        self.__prefab_post_init__(pth=pth)

    ...

    def __prefab_post_init__(self, pth: str | Path):
        self.pth = Path(pth)
```