### PR TITLE
Fixed mixed assignments and class variables being mistaken for assignments (compiled)

### DIFF
--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -1,5 +1,5 @@
-__version__ = "v0.9.2"
-PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.2"
+__version__ = "v0.9.3"
+PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.3"
 
 from .dynamic import prefab, attribute, build_prefab
 from .sentinels import KW_ONLY

--- a/src/prefab_classes_hook/__init__.py
+++ b/src/prefab_classes_hook/__init__.py
@@ -9,8 +9,8 @@ try:
 except ImportError:
     from importlib.machinery import PathFinder, SourceFileLoader
 
-__version__ = "v0.9.2"
-PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.2"
+__version__ = "v0.9.3"
+PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.3"
 
 __all__ = ["prefab_compiler", "insert_prefab_importhook", "remove_prefab_importhook"]
 

--- a/tests/compiled/test_import_compile.py
+++ b/tests/compiled/test_import_compile.py
@@ -25,7 +25,7 @@ def test_mixed_annotations():
 
     assert Y.COMPILED
 
-    assert Y.PREFAB_FIELDS == ["v", "w", "x", "y", "z"]
+    assert Y.PREFAB_FIELDS == ["w", "x", "y", "z"]
 
     y = Y(y="pints")
 

--- a/tests/compiled/test_import_compile.py
+++ b/tests/compiled/test_import_compile.py
@@ -25,7 +25,7 @@ def test_mixed_annotations():
 
     assert Y.COMPILED
 
-    assert Y.PREFAB_FIELDS == ["w", "x", "y", "z"]
+    assert Y.PREFAB_FIELDS == ["v", "w", "x", "y", "z"]
 
     y = Y(y="pints")
 

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -67,3 +67,24 @@ class PositionalNotAfterKW:
     x: int
     y: int = attribute(default=0, init=False)
     z: int
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class SplitVarDef:
+    # Split the definition of x over 2 lines
+    # This should work the same way as defining over 1 line
+    x: str
+    x = "test"
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class SplitVarDefReverseOrder:
+    # This should still work in the reverse order
+    x = "test"
+    x: str
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class SplitVarRedef:
+    # This should only use the last value
+    x: str = "fake_test"
+    x = "test"  # noqa

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -108,3 +108,10 @@ class HorribleMess:
     x: str = "test"  # This should override the init and repr False statements
     y: str = "test_2"
     y: str
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class CallMistakenForAttribute:
+    # Check that a call to str() is no longer mistaken for an attribute call
+    ignore_this = str("this is a class variable")
+    use_this = attribute(default="this is an attribute")

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -88,3 +88,12 @@ class SplitVarRedef:
     # This should only use the last value
     x: str = "fake_test"
     x = "test"  # noqa
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class SplitVarAttribDef:
+    # x here is an attribute, but it *is* typed
+    # So this should still define Y correctly.
+    x: str
+    x = attribute(default="test")
+    y: str = "test_2"

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -68,6 +68,7 @@ class PositionalNotAfterKW:
     y: int = attribute(default=0, init=False)
     z: int
 
+
 @prefab(compile_prefab=True, compile_fallback=True)
 class SplitVarDef:
     # Split the definition of x over 2 lines
@@ -97,3 +98,13 @@ class SplitVarAttribDef:
     x: str
     x = attribute(default="test")
     y: str = "test_2"
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class HorribleMess:
+    # Nobody should write a class like this, but it should still work
+    x: str
+    x = attribute(default="fake_test", init=False, repr=False)
+    x: str = "test"  # This should override the init and repr False statements
+    y: str = "test_2"
+    y: str

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -183,3 +183,13 @@ class TestSplitVarDef:
         inst = cls()
         assert inst.x == "test"
 
+    def test_splitvarattribdef(self, importer):
+        from creation import SplitVarAttribDef as cls
+
+        inst = cls()
+
+        assert 'x' in cls.PREFAB_FIELDS
+        assert 'y' in cls.PREFAB_FIELDS
+
+        assert inst.x == "test"
+        assert inst.y == "test_2"

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -168,3 +168,18 @@ class TestExceptions:
             e_info.value.args[0]
             == "Cannot define both a default value and a default factory."
         )
+
+
+class TestSplitVarDef:
+    # Tests for a split variable definition
+    @pytest.mark.parametrize("classname", ["SplitVarDef", "SplitVarDefReverseOrder", "SplitVarRedef"])
+    def test_splitvardef(self, importer, classname):
+        import creation
+
+        cls = getattr(creation, classname)
+
+        assert cls.__annotations__['x'] == str
+
+        inst = cls()
+        assert inst.x == "test"
+

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -205,3 +205,14 @@ class TestSplitVarDef:
         assert repr(inst) == "HorribleMess(x='true_test', y='test_2')"
 
         assert cls.__annotations__ == {'x': str, 'y': str}
+
+
+def test_call_mistaken(importer):
+    from creation import CallMistakenForAttribute as cls
+
+    # Check that ignore_this is a class variable and use_this is not
+    assert cls.ignore_this == "this is a class variable"
+    assert getattr(cls, "use_this", None) is None
+
+    inst = cls()
+    assert inst.use_this == "this is an attribute"

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -193,3 +193,15 @@ class TestSplitVarDef:
 
         assert inst.x == "test"
         assert inst.y == "test_2"
+
+    def test_horriblemess(self, importer):
+        # Nobody should make a class like this but it should behave
+        # as expected
+        from creation import HorribleMess as cls
+
+        inst = cls(x="true_test")
+
+        assert inst.x == "true_test"
+        assert repr(inst) == "HorribleMess(x='true_test', y='test_2')"
+
+        assert cls.__annotations__ == {'x': str, 'y': str}


### PR DESCRIPTION
While investigating #68 I noticed that any function calls in a plain assignment would be mistaken for an attribute() call. This fixes that and allows for defining an attribute over multiple lines in compiled prefabs (this already worked in dynamic prefabs). When processing compiled prefabs will also remove all assignments to attributes including those that were superseded.