### PR TITLE
Drop py39 support

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12-dev", "3.11", "3.10", "3.9", "pypy-3.9"]
+        python-version: ["3.12-dev", "3.11", "3.10", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,12 @@ authors = [
   { name="David C Ellis" },
 ]
 readme="README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -41,7 +41,6 @@ build = ["build", "twine"]
 
 [tool.black]
 line-length = 88
-target-version = ['py39']
 extend-exclude = '''
 (
     # Don't format generated code

--- a/src/prefab_classes/compiled/generator.py
+++ b/src/prefab_classes/compiled/generator.py
@@ -56,14 +56,14 @@ def _is_kw_only_sentinel(item):
 class Field:
     name: str = attribute()
     field: assignment_type = attribute()
-    default: "None | ast.expr" = attribute(default=None)
-    default_factory: "None | ast.expr" = attribute(default=None)
+    default: None | ast.expr = attribute(default=None)
+    default_factory: None | ast.expr = attribute(default=None)
     init_: bool = attribute(default=True)
     repr_: bool = attribute(default=True)
     compare: bool = attribute(default=True)
     kw_only: bool = attribute(default=False)
     exclude_field: bool = attribute(default=False)
-    annotation: "None | ast.expr" = attribute(default=None)
+    annotation: None | ast.expr = attribute(default=None)
     attribute_func: bool = attribute(default=False)
 
     # Indicator that this Field should be made KW_ONLY
@@ -76,7 +76,7 @@ class Field:
     def ast_attribute(
         self,
         obj_name="self",
-        ctx: "type[ast.Load] | type[ast.Store]" = ast.Load,
+        ctx: type[ast.Load] | type[ast.Store] = ast.Load,
     ):
         """Get the ast.Attribute form for loading this attribute"""
         attrib = ast.Attribute(
@@ -161,22 +161,22 @@ class PrefabDetails:
     compile_slots: bool = attribute(default=False)
 
     # Private internal variables
-    _resolved_fields: "None | dict[str, Field]" = attribute(
+    _resolved_fields: None | dict[str, Field] = attribute(
         default=None, init=False, repr=False, compare=False
     )
-    _prefab_map: "None | dict[str, 'PrefabDetails']" = attribute(
+    _prefab_map: None | dict[str, 'PrefabDetails'] = attribute(
         default=None, init=False, repr=False, compare=False
     )
-    _flag_kw_only: "None | ast.AnnAssign" = attribute(
+    _flag_kw_only: None | ast.AnnAssign = attribute(
         default=None, init=False, repr=False, compare=False
     )
-    _defined_attr_names: "None | set[str]" = attribute(
+    _defined_attr_names: None | set[str] = attribute(
         default=None, init=False, repr=False, compare=False
     )
-    _func_arguments: "None | dict[str, dict[str, None | ast.Expr]]" = attribute(
+    _func_arguments: None | dict[str, dict[str, None | ast.Expr]] = attribute(
         default=None, init=False, repr=False, compare=False
     )
-    _resolved_func_arguments: "None | dict[str, dict[str, None | ast.Expr]]" = attribute(
+    _resolved_func_arguments: None | dict[str, dict[str, None | ast.Expr]] = attribute(
         default=None, init=False, repr=False, compare=False
     )
 

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -409,7 +409,7 @@ def build_prefab(
     attributes: list[tuple[str, Attribute]],
     *,
     bases: tuple[type, ...] = (),
-    class_dict: "None | dict[str, object]" = None,
+    class_dict: None | dict[str, object] = None,
     init=True,
     repr=True,
     eq=True,

--- a/src/prefab_classes/funcs.py
+++ b/src/prefab_classes/funcs.py
@@ -5,7 +5,11 @@ from .constants import FIELDS_ATTRIBUTE
 # Importing from collections.abc brings in collections and is slow.
 # The actual module is _collections_abc so just import that directly.
 # As this module is already imported in python's start this is 'free'
-from _collections_abc import Callable
+# Backup with the 'official' module in case they change things.
+try:
+    from _collections_abc import Callable
+except ImportError:
+    from collections.abc import Callable
 
 
 def is_prefab(o):
@@ -56,7 +60,7 @@ def _as_dict_cache(cls, excludes=None):
     return method
 
 
-def as_dict(inst, *, excludes: "None | tuple[str, ...]" = None) -> dict[str, object]:
+def as_dict(inst, *, excludes: None | tuple[str, ...] = None) -> dict[str, object]:
     """
     Represent the prefab as a dictionary of attribute names stuband values.
     Exclude any keys listed in `excludes`
@@ -71,7 +75,7 @@ def as_dict(inst, *, excludes: "None | tuple[str, ...]" = None) -> dict[str, obj
 
 
 @lru_cache
-def _as_dict_json_wrapper(excludes: "None | tuple[str, ...]" = None):
+def _as_dict_json_wrapper(excludes: None | tuple[str, ...] = None):
     def _as_dict_json_inner(inst):
         """Wrapper that gives a more accurate TypeError message for serialization"""
         try:
@@ -85,7 +89,7 @@ def _as_dict_json_wrapper(excludes: "None | tuple[str, ...]" = None):
 
 
 @lru_cache
-def _get_json_encoder(excludes: "None | tuple[str, ...]" = None):
+def _get_json_encoder(excludes: None | tuple[str, ...] = None):
     import json
 
     return json.JSONEncoder(default=_as_dict_json_wrapper(excludes))
@@ -119,8 +123,8 @@ def _merge_defaults(*defaults):
 def to_json(
     inst,
     *,
-    excludes: "None | tuple[str, ...]" = None,
-    dumps_func: "None | Callable[..., str]" = None,
+    excludes: None | tuple[str, ...] = None,
+    dumps_func: None | Callable[..., str] = None,  # noqa: false pycharm error
     **kwargs,
 ) -> str:
     """


### PR DESCRIPTION
Python 3.9 was only supported to include pypy and now pypy supports 3.10 so support for 3.9 can be dropped.