### PR TITLE
Remove the requirement for `init=False` attributes to have a default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ _build/
 dist/
 perftemp.py
 hyperfine_testfiles/
+
+__pycache__/
+*.pyc

--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -1,5 +1,5 @@
-__version__ = "v0.9.3"
-PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.3"
+__version__ = "v0.9.4"
+PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.4"
 
 from .dynamic import prefab, attribute, build_prefab
 from .sentinels import KW_ONLY

--- a/src/prefab_classes/dynamic/_attribute_class.py
+++ b/src/prefab_classes/dynamic/_attribute_class.py
@@ -34,8 +34,6 @@ class Attribute:
 
     @staticmethod
     def __prefab_pre_init__(init, default, default_factory, kw_only):
-        if not init and default is NOTHING and (default_factory is NOTHING):
-            raise LivePrefabError('Must provide a default value/factory if the attribute is not in init.')
         if kw_only and (not init):
             raise LivePrefabError('Attribute cannot be keyword only if it is not in init.')
         if default is not NOTHING and default_factory is not NOTHING:

--- a/src/prefab_classes/dynamic/_attribute_class_maker/_attribute_template.py
+++ b/src/prefab_classes/dynamic/_attribute_class_maker/_attribute_template.py
@@ -26,12 +26,6 @@ class Attribute:
 
     @staticmethod
     def __prefab_pre_init__(init, default, default_factory, kw_only):
-        if not init and default is NOTHING and default_factory is NOTHING:
-            raise LivePrefabError(
-                "Must provide a default value/factory "
-                "if the attribute is not in init."
-            )
-
         if kw_only and not init:
             raise LivePrefabError(
                 "Attribute cannot be keyword only if it is not in init."

--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -154,13 +154,15 @@ def get_init_maker(*, init_name="__init__"):
             else:
                 if attrib.default_factory is not NOTHING:
                     value = f"_{name}_factory()"
-                else:
+                elif attrib.default is not NOTHING:
                     value = f"_{name}_default"
+                else:
+                    value = None
 
             if name in post_init_args:
                 if attrib.default_factory is not NOTHING:
                     processes.append((name, value))
-            else:
+            elif value is not None:
                 assignments.append((name, value))
 
         if hasattr(cls, PRE_INIT_FUNC):

--- a/src/prefab_classes_hook/__init__.py
+++ b/src/prefab_classes_hook/__init__.py
@@ -9,8 +9,8 @@ try:
 except ImportError:
     from importlib.machinery import PathFinder, SourceFileLoader
 
-__version__ = "v0.9.3"
-PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.3"
+__version__ = "v0.9.4"
+PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.9.4"
 
 __all__ = ["prefab_compiler", "insert_prefab_importhook", "remove_prefab_importhook"]
 

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -121,9 +121,3 @@ class CallMistakenForAttribute:
 class ConstructInitFalse:
     # Check that a class with init=False works even without a default
     x = attribute(init=False)
-
-
-# @prefab(compile_prefab=True, compile_fallback=True)
-# class ConstructInitFalseExclude:
-      # Test a class with init=False and exclude_field=True works
-#     x = attribute(exclude_field=True, init=False)

--- a/tests/shared/examples/creation.py
+++ b/tests/shared/examples/creation.py
@@ -115,3 +115,15 @@ class CallMistakenForAttribute:
     # Check that a call to str() is no longer mistaken for an attribute call
     ignore_this = str("this is a class variable")
     use_this = attribute(default="this is an attribute")
+
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class ConstructInitFalse:
+    # Check that a class with init=False works even without a default
+    x = attribute(init=False)
+
+
+# @prefab(compile_prefab=True, compile_fallback=True)
+# class ConstructInitFalseExclude:
+      # Test a class with init=False and exclude_field=True works
+#     x = attribute(exclude_field=True, init=False)

--- a/tests/shared/examples/fails/creation_4.py
+++ b/tests/shared/examples/fails/creation_4.py
@@ -1,7 +1,0 @@
-# COMPILE_PREFABS
-from prefab_classes import prefab, attribute
-
-
-@prefab(compile_prefab=True, compile_fallback=True)
-class Construct:
-    x = attribute(init=False)

--- a/tests/shared/test_creation.py
+++ b/tests/shared/test_creation.py
@@ -120,14 +120,6 @@ def test_skipped_classvars(importer):
     assert "z" in getattr(IgnoreClassVars, "__dict__")
 
 
-def test_non_init_doesnt_break_syntax():
-    # No syntax error if an attribute with a default is defined
-    # before one without - if init=False for that attribute
-    from creation import PositionalNotAfterKW
-
-    x = PositionalNotAfterKW(1, 2)
-    assert repr(x) == "<prefab PositionalNotAfterKW; x=1, y=0, z=2>"
-
 
 class TestExceptions:
     def test_kw_not_in_init(self, importer):
@@ -149,15 +141,6 @@ class TestExceptions:
             from fails.creation_3 import FailSyntax
 
         assert e_info.value.args[0] == "non-default argument follows default argument"
-
-    def test_no_default_no_init_error(self, importer):
-        with pytest.raises(PrefabError) as e_info:
-            from fails.creation_4 import Construct
-
-        assert (
-            e_info.value.args[0]
-            == "Must provide a default value/factory if the attribute is not in init."
-        )
 
     def test_default_value_and_factory_error(self, importer):
         """Error if defining both a value and a factory"""
@@ -216,3 +199,25 @@ def test_call_mistaken(importer):
 
     inst = cls()
     assert inst.use_this == "this is an attribute"
+
+
+@pytest.mark.usefixtures("importer")
+class TestNonInit:
+    def test_non_init_works_no_default(self):
+        from creation import ConstructInitFalse
+
+        x = ConstructInitFalse()
+
+        assert not hasattr(x, "x")
+
+        x.x = 12
+
+        assert repr(x) == "<prefab ConstructInitFalse; x=12>"
+
+    def test_non_init_doesnt_break_syntax(self):
+        # No syntax error if an attribute with a default is defined
+        # before one without - if init=False for that attribute
+        from creation import PositionalNotAfterKW
+
+        x = PositionalNotAfterKW(1, 2)
+        assert repr(x) == "<prefab PositionalNotAfterKW; x=1, y=0, z=2>"


### PR DESCRIPTION
This is useful for setting up attributes that will be assigned based on other values in __prefab_post_init__.

There is no requirement to do so however.