### PR TITLE
Fix inheritance inconsistency

### DIFF
--- a/tests/compiled/test_clearimport.py
+++ b/tests/compiled/test_clearimport.py
@@ -1,3 +1,8 @@
+"""
+Test that prefab_classes imports are removed correctly after importing the module.
+Check they are only removed if they are not otherwise used.
+"""
+
 import pytest
 
 from prefab_classes_hook import prefab_compiler

--- a/tests/shared/examples/inheritance.py
+++ b/tests/shared/examples/inheritance.py
@@ -40,3 +40,23 @@ class BasePreInitPostInit:
 @prefab(compile_prefab=True, compile_fallback=True)
 class ChildPreInitPostInit(BasePreInitPostInit):
     pass
+
+# Multiple inheritance inconsistency test classes
+# classvar and field should be equal
+@prefab(compile_prefab=True, compile_fallback=True)
+class Base:
+    field: int = 10
+    classvar = 10
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class Child1(Base):
+    pass
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class Child2(Base):
+    field: int = 50
+    classvar = 50
+
+@prefab(compile_prefab=True, compile_fallback=True)
+class GrandChild(Child1, Child2):
+    pass

--- a/tests/shared/test_inheritance.py
+++ b/tests/shared/test_inheritance.py
@@ -50,3 +50,10 @@ def test_inherited_pre_post_init(importer):
     inherit_ex = ChildPreInitPostInit()
     assert inherit_ex.pre_init
     assert inherit_ex.post_init
+
+
+def test_mro_correct(importer):
+    from inheritance import GrandChild
+    ex = GrandChild()
+
+    assert ex.field == ex.classvar


### PR DESCRIPTION
Fix the inheritance discrepancy between compiled and dynamic prefabs.

This generates a bunch of stub classes which will have the correct __mro__, extracts the names and puts them in the classes used to generate the prefabs in order to correctly handle inheritance as expected.

Closes #71 