### PR TITLE
Change scope of test fixture to fix errors from pytest update

### DIFF
--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -17,8 +17,8 @@ __all__ = [
     "is_prefab_instance",
 ]
 
-__version__ = "v0.10.1"
-PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.10.1"
+__version__ = "v0.10.2"
+PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.10.2"
 
 _imports = [
     MultiFromImport(".dynamic", ["prefab", "attribute", "build_prefab"]),

--- a/tests/shared/conftest.py
+++ b/tests/shared/conftest.py
@@ -27,7 +27,7 @@ def clear_pycache(base_path):
         shutil.rmtree(compiled_data)
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def example_modules():
     # Folder with test examples to compile
     base_path = Path(__file__).parent / "examples"


### PR DESCRIPTION
It seems the 'module' scope is no longer working as it used to, so the modules do not get removed from cache between test module runs.

This switches the scope to function, which sadly makes the tests slower but at least means they *are* testing both implementations instead of testing one implementation twice (under the new pytest).

This will probably only properly be resolved if/when I remove support for the AST based implementation.