### PR TITLE
Fix self in pre post init

### DIFF
--- a/src/prefab_classes/dynamic/method_generators.py
+++ b/src/prefab_classes/dynamic/method_generators.py
@@ -101,11 +101,13 @@ def get_init_maker(*, init_name="__init__"):
                 pass
             else:
                 argcount = func_code.co_argcount + func_code.co_kwonlyargcount
-                arglist = func_code.co_varnames[:argcount]
 
-                for item in arglist:
-                    if item != "self":
-                        func_arglist.append(item)
+                # Identify if method is static, if so include first arg, otherwise skip
+                is_static = type(cls.__dict__.get(func_name)) is staticmethod
+
+                arglist = func_code.co_varnames[:argcount] if is_static else func_code.co_varnames[1:argcount]
+
+                func_arglist.extend(arglist)
 
                 if func_name == POST_INIT_FUNC:
                     post_init_annotations.update(func.__annotations__)

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -354,10 +354,14 @@ def _make_prefab(
             )
 
         argcount = func_code.co_argcount + func_code.co_kwonlyargcount
-        arglist = func_code.co_varnames[:argcount]
+
+        # Include the first argument if the method is static
+        is_static = type(cls.__dict__.get(PRE_INIT_FUNC)) is staticmethod
+
+        arglist = func_code.co_varnames[:argcount] if is_static else func_code.co_varnames[1:argcount]
 
         for item in arglist:
-            if item not in attributes.keys() and item != "self":
+            if item not in attributes.keys():
                 raise LivePrefabError(
                     f"{item} argument in __prefab_pre_init__ is not a valid attribute."
                 )
@@ -375,15 +379,19 @@ def _make_prefab(
             )
 
         argcount = func_code.co_argcount + func_code.co_kwonlyargcount
-        arglist = func_code.co_varnames[:argcount]
+
+        # Include the first argument if the method is static
+        is_static = type(cls.__dict__.get(POST_INIT_FUNC)) is staticmethod
+
+        arglist = func_code.co_varnames[:argcount] if is_static else func_code.co_varnames[1:argcount]
 
         for item in arglist:
-            if item != "self":
-                if item not in attributes.keys():
-                    raise LivePrefabError(
-                        f"{item} argument in __prefab_post_init__ is not a valid attribute."
-                    )
-                post_init_args.append(item)
+            if item not in attributes.keys():
+                raise LivePrefabError(
+                    f"{item} argument in __prefab_post_init__ is not a valid attribute."
+                )
+
+        post_init_args.extend(arglist)
 
     default_defined = []
     valid_fields = []

--- a/tests/dynamic/test_pre_post_init.py
+++ b/tests/dynamic/test_pre_post_init.py
@@ -36,3 +36,23 @@ def test_pre_init_static():
 
     with pytest.raises(ValueError):
         ex = PreInitStatic(2, 1)
+
+
+def test_post_init_not_self():
+    @prefab
+    class PostInitNotSelf:
+        x: int = 1
+        y: int = 2
+
+        def __prefab_post_init__(this, x, y):
+            if x > y:
+                raise ValueError("X must be less than Y")
+
+            this.x = x
+            this.y = y
+
+    ex = PostInitNotSelf(1, 2)
+
+    with pytest.raises(ValueError):
+        ex = PostInitNotSelf(2, 1)
+

--- a/tests/dynamic/test_pre_post_init.py
+++ b/tests/dynamic/test_pre_post_init.py
@@ -1,0 +1,38 @@
+# Most pre/post init tests are shared currently
+# This is a new test for using identifiers other than 'self' as the first argument
+import pytest
+
+from prefab_classes import prefab
+
+
+def test_pre_init_not_self():
+    @prefab
+    class PreInitNotSelf:
+        x: int = 1
+        y: int = 2
+
+        def __prefab_pre_init__(this, x, y):
+            if x > y:
+                raise ValueError("X must be less than Y")
+
+    ex = PreInitNotSelf(1, 2)
+
+    with pytest.raises(ValueError):
+        ex = PreInitNotSelf(2, 1)
+
+
+def test_pre_init_static():
+    @prefab
+    class PreInitStatic:
+        x: int = 1
+        y: int = 2
+
+        @staticmethod
+        def __prefab_pre_init__(x, y):
+            if x > y:
+                raise ValueError("X must be less than Y")
+
+    ex = PreInitStatic(1, 2)
+
+    with pytest.raises(ValueError):
+        ex = PreInitStatic(2, 1)


### PR DESCRIPTION
Fix a bug where names other than "self" for the first argument in pre/post init functions would raise an exception.

Only fixed for dynamic classes as compiled classes are deprecated.

I noticed this while working on the changes to remove compiled prefabs.