### PR TITLE
Check if attributes are in slots before processing defaults.

### DIFF
--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -17,8 +17,8 @@ __all__ = [
     "is_prefab_instance",
 ]
 
-__version__ = "v0.11.0"
-PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.11.0"
+__version__ = "v0.11.1"
+PREFAB_MAGIC_BYTES = b"PREFAB_CLASSES_v0.11.1"
 
 _imports = [
     MultiFromImport(".dynamic", ["prefab", "attribute", "build_prefab"]),

--- a/src/prefab_classes/dynamic/prefab.py
+++ b/src/prefab_classes/dynamic/prefab.py
@@ -294,7 +294,8 @@ def _make_prefab(
             else:
                 # Copy atributes that are already defined to the new dict
                 # generate Attribute() values for those that are not defined.
-                if hasattr(cls, name):
+                cls_slots = getattr(cls, "__slots__", {})
+                if hasattr(cls, name) and name not in cls_slots:
                     if name in cls_attribute_names:
                         attrib = cls_attributes[name]
                     else:

--- a/tests/dynamic/test_slots_novalues.py
+++ b/tests/dynamic/test_slots_novalues.py
@@ -1,0 +1,17 @@
+import pytest
+from prefab_classes import prefab
+
+
+def test_fail_slots():
+    @prefab
+    class SlotPrefab:
+        __slots__ = ("x", "y")
+        x: int
+        y: str
+
+    sp = SlotPrefab(1, "demo")
+    sp2 = SlotPrefab(1, "demo")
+    assert sp.x == 1
+    assert sp.y == "demo"
+
+    assert sp == sp2


### PR DESCRIPTION
Fixes a bug that prevented creating prefabs with type hints and no default values and slots.