### PR TITLE
Deprecate this module in favour of ducktools-classbuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PrefabClasses - Python Class Boilerplate Generator  #
 ![PrefabClasses Test Status](https://github.com/DavidCEllis/PrefabClasses/actions/workflows/auto_test.yml/badge.svg?branch=main)
 
-> [!WARN] `prefab_classes` is being deprecated in favour 
+> [!WARNING] `prefab_classes` is being deprecated in favour 
 > of `ducktools.classbuilder.prefab` which is a mostly compatible
 > reimplementation.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > 
 > `python -m pip install ducktools-classbuilder`
 > 
-> The only (intentional) changes int that module are:
+> The only (intentional) changes in that module are:
 >   * `SlotAttributes` is now `SlotFields`
 >   * `as_dict` is in the main module and does not cache
 >   * `@prefab(dict_method=True)` will create a cached as_dict 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # PrefabClasses - Python Class Boilerplate Generator  #
 ![PrefabClasses Test Status](https://github.com/DavidCEllis/PrefabClasses/actions/workflows/auto_test.yml/badge.svg?branch=main)
 
+> [!WARN] `prefab_classes` is being deprecated in favour 
+> of `ducktools.classbuilder.prefab` which is a mostly compatible
+> reimplementation.
+
 Writes the class boilerplate code so you don't have to. 
 Yet another variation on attrs/dataclasses.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # PrefabClasses - Python Class Boilerplate Generator  #
 ![PrefabClasses Test Status](https://github.com/DavidCEllis/PrefabClasses/actions/workflows/auto_test.yml/badge.svg?branch=main)
 
-> [!WARNING] `prefab_classes` is being deprecated in favour 
-> of `ducktools.classbuilder.prefab` which is a mostly compatible
+> [!WARNING] 
+> `prefab_classes` is being deprecated in favour of 
+> `ducktools.classbuilder.prefab` which is a mostly compatible
 > reimplementation.
 
 Writes the class boilerplate code so you don't have to. 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,20 @@
 
 > [!WARNING] 
 > `prefab_classes` is being deprecated in favour of 
-> `ducktools.classbuilder.prefab` which is a mostly compatible
-> reimplementation.
+> the prefab submodule of [ducktools-classbuilder](https://github.com/DavidCEllis/ducktools-classbuilder) 
+> which is a mostly compatible reimplementation.
 > 
 > This can be obtained using:
 > 
 > `python -m pip install ducktools-classbuilder`
 > 
-> [ducktools.classbuilder](https://github.com/DavidCEllis/ducktools-classbuilder)
+> The only (intentional) changes int that module are:
+>   * `SlotAttributes` is now `SlotFields`
+>   * `as_dict` is in the main module and does not cache
+>   * `@prefab(dict_method=True)` will create a cached as_dict 
+>     method on the class that the function will automatically 
+>     use.
+>   * `to_json` no longer exists - just use `json.dumps(obj, default=as_dict)`
 
 Writes the class boilerplate code so you don't have to. 
 Yet another variation on attrs/dataclasses.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 >   * `@prefab(dict_method=True)` will create a cached as_dict 
 >     method on the class that the function will automatically 
 >     use.
+>   * attributes are excluded from `as_dict` using the `serialize` argument to `attribute`
 >   * `to_json` no longer exists - just use `json.dumps(obj, default=as_dict)`
 
 Writes the class boilerplate code so you don't have to. 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 > `prefab_classes` is being deprecated in favour of 
 > `ducktools.classbuilder.prefab` which is a mostly compatible
 > reimplementation.
+> 
+> This can be obtained using:
+> 
+> `python -m pip install ducktools-classbuilder`
 
 Writes the class boilerplate code so you don't have to. 
 Yet another variation on attrs/dataclasses.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 > This can be obtained using:
 > 
 > `python -m pip install ducktools-classbuilder`
+> 
+> [ducktools.classbuilder](https://github.com/DavidCEllis/ducktools-classbuilder)
 
 Writes the class boilerplate code so you don't have to. 
 Yet another variation on attrs/dataclasses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,22 @@ api
 ```
 
 ```{warning}
-`prefab_classes` is being deprecated in favour of `ducktools.classbuilder.prefab` 
+`prefab_classes` is being deprecated in favour of 
+the prefab submodule of [ducktools-classbuilder](https://github.com/DavidCEllis/ducktools-classbuilder) 
 which is a mostly compatible reimplementation.
 
 This can be obtained using:
 
 `python -m pip install ducktools-classbuilder`
+
+The only (intentional) changes in that module are:
+  * `SlotAttributes` is now `SlotFields`
+  * `as_dict` is in the main module and does not cache
+  * `@prefab(dict_method=True)` will create a cached as_dict 
+    method on the class that the function will automatically 
+    use.
+  * attributes are excluded from `as_dict` using the `serialize` argument to `attribute`
+  * `to_json` no longer exists - just use `json.dumps(obj, default=as_dict)`
 ```
 
 Prefab Classes is a package that automatically generates basic class magic

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,15 @@ extra/performance_tests
 api
 ```
 
+```{warning}
+`prefab_classes` is being deprecated in favour of `ducktools.classbuilder.prefab` 
+which is a mostly compatible reimplementation.
+
+This can be obtained using:
+
+`python -m pip install ducktools-classbuilder`
+```
+
 Prefab Classes is a package that automatically generates basic class magic
 methods so you don't have to write them yourself.
 
@@ -116,8 +125,6 @@ class Settings:
 You have probably seen something like this before if you've looked into the `dataclasses`
 module or the `attrs` package. The main difference for `prefab_classes` is in the
 implementation, although there are also some other design differences.
-
-See {doc}`getting_started` for more examples and more detailed explanation on usage.
 
 ## Indices and tables ##
 * {ref}`genindex`

--- a/src/prefab_classes/__init__.py
+++ b/src/prefab_classes/__init__.py
@@ -20,6 +20,15 @@
 # SOFTWARE.
 # ==============================================================================
 
+import warnings
+
+warnings.warn(
+    DeprecationWarning(
+        "PrefabClasses is being deprecated in favour of ducktools-classbuilder"
+    )
+)
+
+
 from ducktools.lazyimporter import (
     LazyImporter,
     MultiFromImport,


### PR DESCRIPTION
This package has largely been remade in `ducktools.classbuilder` but in a more modular way.

I've wanted to deprecate this for a while as it is the only package I've released not in the `ducktools` namespace.

This PR will add a `DeprecationWarning`, a note on the readme, and a note on the docs.